### PR TITLE
Prepare for release v0.11.1

### DIFF
--- a/hub/resourceeditors/acme.cert-manager.io/v1/challenges.yaml
+++ b/hub/resourceeditors/acme.cert-manager.io/v1/challenges.yaml
@@ -29,4 +29,4 @@ spec:
     editor:
       name: acmecertmanagerio-challenge-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/acme.cert-manager.io/v1/orders.yaml
+++ b/hub/resourceeditors/acme.cert-manager.io/v1/orders.yaml
@@ -29,4 +29,4 @@ spec:
     editor:
       name: acmecertmanagerio-order-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations.yaml
+++ b/hub/resourceeditors/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: admissionregistrationk8sio-mutatingwebhookconfiguration-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/admissionregistration.k8s.io/v1/validatingwebhookconfigurations.yaml
+++ b/hub/resourceeditors/admissionregistration.k8s.io/v1/validatingwebhookconfigurations.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: admissionregistrationk8sio-validatingwebhookconfiguration-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/apiextensions.k8s.io/v1/customresourcedefinitions.yaml
+++ b/hub/resourceeditors/apiextensions.k8s.io/v1/customresourcedefinitions.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: apiextensionsk8sio-customresourcedefinition-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/apiregistration.k8s.io/v1/apiservices.yaml
+++ b/hub/resourceeditors/apiregistration.k8s.io/v1/apiservices.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: apiregistrationk8sio-apiservice-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/app.k8s.io/v1beta1/applications.yaml
+++ b/hub/resourceeditors/app.k8s.io/v1beta1/applications.yaml
@@ -19,6 +19,6 @@ spec:
     editor:
       name: appk8sio-application-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6
     instanceLabelPaths:
     - spec.selector.matchLabels

--- a/hub/resourceeditors/appcatalog.appscode.com/v1alpha1/appbindings.yaml
+++ b/hub/resourceeditors/appcatalog.appscode.com/v1alpha1/appbindings.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: appcatalogappscodecom-appbinding-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/apps/v1/daemonsets.yaml
+++ b/hub/resourceeditors/apps/v1/daemonsets.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: apps-daemonset-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/apps/v1/deployments.yaml
+++ b/hub/resourceeditors/apps/v1/deployments.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: apps-deployment-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/apps/v1/replicasets.yaml
+++ b/hub/resourceeditors/apps/v1/replicasets.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: apps-replicaset-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/apps/v1/statefulsets.yaml
+++ b/hub/resourceeditors/apps/v1/statefulsets.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: apps-statefulset-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/auditor.appscode.com/v1alpha1/siteinfos.yaml
+++ b/hub/resourceeditors/auditor.appscode.com/v1alpha1/siteinfos.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: auditorappscodecom-siteinfo-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/auditregistration.k8s.io/v1alpha1/auditsinks.yaml
+++ b/hub/resourceeditors/auditregistration.k8s.io/v1alpha1/auditsinks.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: auditregistrationk8sio-auditsink-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/autoscaling.k8s.io/v1/verticalpodautoscalercheckpoints.yaml
+++ b/hub/resourceeditors/autoscaling.k8s.io/v1/verticalpodautoscalercheckpoints.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: autoscalingk8sio-verticalpodautoscalercheckpoint-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/autoscaling.k8s.io/v1/verticalpodautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.k8s.io/v1/verticalpodautoscalers.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: autoscalingk8sio-verticalpodautoscaler-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/elasticsearchautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/elasticsearchautoscalers.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: autoscalingkubedbcom-elasticsearchautoscaler-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/etcdautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/etcdautoscalers.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: autoscalingkubedbcom-etcdautoscaler-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mariadbautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mariadbautoscalers.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: autoscalingkubedbcom-mariadbautoscaler-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/memcachedautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/memcachedautoscalers.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: autoscalingkubedbcom-memcachedautoscaler-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mongodbautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mongodbautoscalers.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: autoscalingkubedbcom-mongodbautoscaler-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mysqlautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mysqlautoscalers.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: autoscalingkubedbcom-mysqlautoscaler-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/perconaxtradbautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/perconaxtradbautoscalers.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: autoscalingkubedbcom-perconaxtradbautoscaler-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/pgbouncerautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/pgbouncerautoscalers.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: autoscalingkubedbcom-pgbouncerautoscaler-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/postgresautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/postgresautoscalers.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: autoscalingkubedbcom-postgresautoscaler-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/proxysqlautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/proxysqlautoscalers.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: autoscalingkubedbcom-proxysqlautoscaler-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/redisautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/redisautoscalers.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: autoscalingkubedbcom-redisautoscaler-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/autoscaling/v2beta2/horizontalpodautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling/v2beta2/horizontalpodautoscalers.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: autoscaling-horizontalpodautoscaler-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/batch/v1/cronjobs.yaml
+++ b/hub/resourceeditors/batch/v1/cronjobs.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: batch-cronjob-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/batch/v1/jobs.yaml
+++ b/hub/resourceeditors/batch/v1/jobs.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: batch-job-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/batch/v1beta1/cronjobs.yaml
+++ b/hub/resourceeditors/batch/v1beta1/cronjobs.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: batch-cronjob-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/elasticsearchversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/elasticsearchversions.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: catalogkubedbcom-elasticsearchversion-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/etcdversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/etcdversions.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: catalogkubedbcom-etcdversion-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mariadbversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mariadbversions.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: catalogkubedbcom-mariadbversion-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/memcachedversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/memcachedversions.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: catalogkubedbcom-memcachedversion-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mongodbversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mongodbversions.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: catalogkubedbcom-mongodbversion-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mysqlversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mysqlversions.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: catalogkubedbcom-mysqlversion-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/perconaxtradbversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/perconaxtradbversions.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: catalogkubedbcom-perconaxtradbversion-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/pgbouncerversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/pgbouncerversions.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: catalogkubedbcom-pgbouncerversion-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/postgresversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/postgresversions.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: catalogkubedbcom-postgresversion-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/proxysqlversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/proxysqlversions.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: catalogkubedbcom-proxysqlversion-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/redisversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/redisversions.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: catalogkubedbcom-redisversion-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/catalog.kubevault.com/v1alpha1/vaultserverversions.yaml
+++ b/hub/resourceeditors/catalog.kubevault.com/v1alpha1/vaultserverversions.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: catalogkubevaultcom-vaultserverversion-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/cert-manager.io/v1/certificaterequests.yaml
+++ b/hub/resourceeditors/cert-manager.io/v1/certificaterequests.yaml
@@ -29,4 +29,4 @@ spec:
     editor:
       name: certmanagerio-certificaterequest-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/cert-manager.io/v1/certificates.yaml
+++ b/hub/resourceeditors/cert-manager.io/v1/certificates.yaml
@@ -29,4 +29,4 @@ spec:
     editor:
       name: certmanagerio-certificate-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/cert-manager.io/v1/clusterissuers.yaml
+++ b/hub/resourceeditors/cert-manager.io/v1/clusterissuers.yaml
@@ -29,4 +29,4 @@ spec:
     editor:
       name: certmanagerio-clusterissuer-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/cert-manager.io/v1/issuers.yaml
+++ b/hub/resourceeditors/cert-manager.io/v1/issuers.yaml
@@ -29,4 +29,4 @@ spec:
     editor:
       name: certmanagerio-issuer-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/certificates.k8s.io/v1/certificatesigningrequests.yaml
+++ b/hub/resourceeditors/certificates.k8s.io/v1/certificatesigningrequests.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: certificatesk8sio-certificatesigningrequest-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/certificates.k8s.io/v1beta1/certificatesigningrequests.yaml
+++ b/hub/resourceeditors/certificates.k8s.io/v1beta1/certificatesigningrequests.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: certificatesk8sio-certificatesigningrequest-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/cluster.x-k8s.io/v1alpha3/machines.yaml
+++ b/hub/resourceeditors/cluster.x-k8s.io/v1alpha3/machines.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: clusterxk8sio-machine-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/cluster.x-k8s.io/v1alpha3/machinesets.yaml
+++ b/hub/resourceeditors/cluster.x-k8s.io/v1alpha3/machinesets.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: clusterxk8sio-machineset-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/coordination.k8s.io/v1/leases.yaml
+++ b/hub/resourceeditors/coordination.k8s.io/v1/leases.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: coordinationk8sio-lease-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/core/v1/bindings.yaml
+++ b/hub/resourceeditors/core/v1/bindings.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: core-binding-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/core/v1/componentstatuses.yaml
+++ b/hub/resourceeditors/core/v1/componentstatuses.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: core-componentstatus-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/core/v1/configmaps.yaml
+++ b/hub/resourceeditors/core/v1/configmaps.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: core-configmap-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/core/v1/endpoints.yaml
+++ b/hub/resourceeditors/core/v1/endpoints.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: core-endpoints-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/core/v1/ephemeralcontainers.yaml
+++ b/hub/resourceeditors/core/v1/ephemeralcontainers.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: core-ephemeralcontainers-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/core/v1/events.yaml
+++ b/hub/resourceeditors/core/v1/events.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: core-event-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/core/v1/limitranges.yaml
+++ b/hub/resourceeditors/core/v1/limitranges.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: core-limitrange-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/core/v1/namespaces.yaml
+++ b/hub/resourceeditors/core/v1/namespaces.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: core-namespace-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/core/v1/nodes.yaml
+++ b/hub/resourceeditors/core/v1/nodes.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: core-node-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/core/v1/persistentvolumeclaims.yaml
+++ b/hub/resourceeditors/core/v1/persistentvolumeclaims.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: core-persistentvolumeclaim-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/core/v1/persistentvolumes.yaml
+++ b/hub/resourceeditors/core/v1/persistentvolumes.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: core-persistentvolume-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/core/v1/pods.yaml
+++ b/hub/resourceeditors/core/v1/pods.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: core-pod-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/core/v1/podstatusresults.yaml
+++ b/hub/resourceeditors/core/v1/podstatusresults.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: core-podstatusresult-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/core/v1/podtemplates.yaml
+++ b/hub/resourceeditors/core/v1/podtemplates.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: core-podtemplate-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/core/v1/rangeallocations.yaml
+++ b/hub/resourceeditors/core/v1/rangeallocations.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: core-rangeallocation-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/core/v1/replicationcontrollers.yaml
+++ b/hub/resourceeditors/core/v1/replicationcontrollers.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: core-replicationcontroller-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/core/v1/resourcequota.yaml
+++ b/hub/resourceeditors/core/v1/resourcequota.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: core-resourcequota-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/core/v1/resourcequotas.yaml
+++ b/hub/resourceeditors/core/v1/resourcequotas.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: core-resourcequota-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/core/v1/secrets.yaml
+++ b/hub/resourceeditors/core/v1/secrets.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: core-secret-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/core/v1/serviceaccounts.yaml
+++ b/hub/resourceeditors/core/v1/serviceaccounts.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: core-serviceaccount-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/core/v1/services.yaml
+++ b/hub/resourceeditors/core/v1/services.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: core-service-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/discovery.k8s.io/v1/endpointslice.yaml
+++ b/hub/resourceeditors/discovery.k8s.io/v1/endpointslice.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: discoveryk8sio-endpointslice-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/discovery.k8s.io/v1beta1/endpointslice.yaml
+++ b/hub/resourceeditors/discovery.k8s.io/v1beta1/endpointslice.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: discoveryk8sio-endpointslice-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/discovery.k8s.io/v1beta1/endpointslices.yaml
+++ b/hub/resourceeditors/discovery.k8s.io/v1beta1/endpointslices.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: discoveryk8sio-endpointslice-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/engine.kubevault.com/v1alpha1/awsroles.yaml
+++ b/hub/resourceeditors/engine.kubevault.com/v1alpha1/awsroles.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: enginekubevaultcom-awsrole-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/engine.kubevault.com/v1alpha1/azureroles.yaml
+++ b/hub/resourceeditors/engine.kubevault.com/v1alpha1/azureroles.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: enginekubevaultcom-azurerole-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/engine.kubevault.com/v1alpha1/elasticsearchroles.yaml
+++ b/hub/resourceeditors/engine.kubevault.com/v1alpha1/elasticsearchroles.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: enginekubevaultcom-elasticsearchrole-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/engine.kubevault.com/v1alpha1/gcproles.yaml
+++ b/hub/resourceeditors/engine.kubevault.com/v1alpha1/gcproles.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: enginekubevaultcom-gcprole-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/engine.kubevault.com/v1alpha1/mongodbroles.yaml
+++ b/hub/resourceeditors/engine.kubevault.com/v1alpha1/mongodbroles.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: enginekubevaultcom-mongodbrole-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/engine.kubevault.com/v1alpha1/mysqlroles.yaml
+++ b/hub/resourceeditors/engine.kubevault.com/v1alpha1/mysqlroles.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: enginekubevaultcom-mysqlrole-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/engine.kubevault.com/v1alpha1/postgresroles.yaml
+++ b/hub/resourceeditors/engine.kubevault.com/v1alpha1/postgresroles.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: enginekubevaultcom-postgresrole-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretaccessrequests.yaml
+++ b/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretaccessrequests.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: enginekubevaultcom-secretaccessrequest-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretengines.yaml
+++ b/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretengines.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: enginekubevaultcom-secretengine-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretrolebindings.yaml
+++ b/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretrolebindings.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: enginekubevaultcom-secretrolebinding-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/events.k8s.io/v1/events.yaml
+++ b/hub/resourceeditors/events.k8s.io/v1/events.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: eventsk8sio-event-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/events.k8s.io/v1beta1/events.yaml
+++ b/hub/resourceeditors/events.k8s.io/v1beta1/events.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: eventsk8sio-event-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/extensions/v1beta1/daemonsets.yaml
+++ b/hub/resourceeditors/extensions/v1beta1/daemonsets.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: extensions-daemonset-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/extensions/v1beta1/deployments.yaml
+++ b/hub/resourceeditors/extensions/v1beta1/deployments.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: extensions-deployment-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/extensions/v1beta1/ingresses.yaml
+++ b/hub/resourceeditors/extensions/v1beta1/ingresses.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: extensions-ingress-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/extensions/v1beta1/networkpolicies.yaml
+++ b/hub/resourceeditors/extensions/v1beta1/networkpolicies.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: extensions-networkpolicy-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/extensions/v1beta1/podsecuritypolicies.yaml
+++ b/hub/resourceeditors/extensions/v1beta1/podsecuritypolicies.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: extensions-podsecuritypolicy-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/extensions/v1beta1/replicasets.yaml
+++ b/hub/resourceeditors/extensions/v1beta1/replicasets.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: extensions-replicaset-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/extensions/v1beta1/scales.yaml
+++ b/hub/resourceeditors/extensions/v1beta1/scales.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: extensions-scale-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1alpha1/flowschemas.yaml
+++ b/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1alpha1/flowschemas.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: flowcontrolapiserverk8sio-flowschema-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1alpha1/prioritylevelconfigurations.yaml
+++ b/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1alpha1/prioritylevelconfigurations.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: flowcontrolapiserverk8sio-prioritylevelconfiguration-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1beta1/flowschemas.yaml
+++ b/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1beta1/flowschemas.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: flowcontrolapiserverk8sio-flowschema-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1beta1/prioritylevelconfigurations.yaml
+++ b/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1beta1/prioritylevelconfigurations.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: flowcontrolapiserverk8sio-prioritylevelconfiguration-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/imagepolicy.k8s.io/v1alpha1/imagereviews.yaml
+++ b/hub/resourceeditors/imagepolicy.k8s.io/v1alpha1/imagereviews.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: imagepolicyk8sio-imagereview-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/internal.apiserver.k8s.io/v1alpha1/storageversions.yaml
+++ b/hub/resourceeditors/internal.apiserver.k8s.io/v1alpha1/storageversions.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: internalapiserverk8sio-storageversion-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/kubedb.com/v1alpha2/elasticsearches.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/elasticsearches.yaml
@@ -24,8 +24,8 @@ spec:
     editor:
       name: kubedbcom-elasticsearch-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6
     options:
       name: kubedbcom-elasticsearch-editor-options
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/kubedb.com/v1alpha2/etcds.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/etcds.yaml
@@ -24,8 +24,8 @@ spec:
     editor:
       name: kubedbcom-etcd-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6
     options:
       name: kubedbcom-etcd-editor-options
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/kubedb.com/v1alpha2/mariadbs.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/mariadbs.yaml
@@ -24,8 +24,8 @@ spec:
     editor:
       name: kubedbcom-mariadb-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6
     options:
       name: kubedbcom-mariadb-editor-options
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/kubedb.com/v1alpha2/memcacheds.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/memcacheds.yaml
@@ -24,8 +24,8 @@ spec:
     editor:
       name: kubedbcom-memcached-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6
     options:
       name: kubedbcom-memcached-editor-options
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/kubedb.com/v1alpha2/mongodbs.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/mongodbs.yaml
@@ -24,8 +24,8 @@ spec:
     editor:
       name: kubedbcom-mongodb-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6
     options:
       name: kubedbcom-mongodb-editor-options
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/kubedb.com/v1alpha2/mysqls.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/mysqls.yaml
@@ -24,8 +24,8 @@ spec:
     editor:
       name: kubedbcom-mysql-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6
     options:
       name: kubedbcom-mysql-editor-options
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/kubedb.com/v1alpha2/perconaxtradbs.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/perconaxtradbs.yaml
@@ -24,8 +24,8 @@ spec:
     editor:
       name: kubedbcom-perconaxtradb-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6
     options:
       name: kubedbcom-perconaxtradb-editor-options
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/kubedb.com/v1alpha2/pgbouncers.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/pgbouncers.yaml
@@ -24,8 +24,8 @@ spec:
     editor:
       name: kubedbcom-pgbouncer-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6
     options:
       name: kubedbcom-pgbouncer-editor-options
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/kubedb.com/v1alpha2/postgreses.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/postgreses.yaml
@@ -24,8 +24,8 @@ spec:
     editor:
       name: kubedbcom-postgres-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6
     options:
       name: kubedbcom-postgres-editor-options
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/kubedb.com/v1alpha2/proxysqls.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/proxysqls.yaml
@@ -24,8 +24,8 @@ spec:
     editor:
       name: kubedbcom-proxysql-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6
     options:
       name: kubedbcom-proxysql-editor-options
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/kubedb.com/v1alpha2/redises.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/redises.yaml
@@ -24,8 +24,8 @@ spec:
     editor:
       name: kubedbcom-redis-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6
     options:
       name: kubedbcom-redis-editor-options
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/kubedb.com/v1alpha2/redissentinels.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/redissentinels.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: kubedbcom-redissentinel-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/kubevault.com/v1alpha1/vaultservers.yaml
+++ b/hub/resourceeditors/kubevault.com/v1alpha1/vaultservers.yaml
@@ -24,8 +24,8 @@ spec:
     editor:
       name: kubevaultcom-vaultserver-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6
     options:
       name: kubevaultcom-vaultserver-editor-options
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/meta.appscode.com/v1alpha1/resourcedescriptors.yaml
+++ b/hub/resourceeditors/meta.appscode.com/v1alpha1/resourcedescriptors.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: metaappscodecom-resourcedescriptor-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/metrics.appscode.com/v1alpha1/metricsconfigurations.yaml
+++ b/hub/resourceeditors/metrics.appscode.com/v1alpha1/metricsconfigurations.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: metricsappscodecom-metricsconfiguration-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/monitoring.coreos.com/v1/alertmanagers.yaml
+++ b/hub/resourceeditors/monitoring.coreos.com/v1/alertmanagers.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: monitoringcoreoscom-alertmanager-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/monitoring.coreos.com/v1/podmonitors.yaml
+++ b/hub/resourceeditors/monitoring.coreos.com/v1/podmonitors.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: monitoringcoreoscom-podmonitor-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/monitoring.coreos.com/v1/probes.yaml
+++ b/hub/resourceeditors/monitoring.coreos.com/v1/probes.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: monitoringcoreoscom-probe-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/monitoring.coreos.com/v1/prometheuses.yaml
+++ b/hub/resourceeditors/monitoring.coreos.com/v1/prometheuses.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: monitoringcoreoscom-prometheus-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/monitoring.coreos.com/v1/prometheusrules.yaml
+++ b/hub/resourceeditors/monitoring.coreos.com/v1/prometheusrules.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: monitoringcoreoscom-prometheusrule-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/monitoring.coreos.com/v1/servicemonitors.yaml
+++ b/hub/resourceeditors/monitoring.coreos.com/v1/servicemonitors.yaml
@@ -24,6 +24,6 @@ spec:
     editor:
       name: monitoringcoreoscom-servicemonitor-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6
     instanceLabelPaths:
     - spec.selector.matchLabels

--- a/hub/resourceeditors/monitoring.coreos.com/v1/thanosrulers.yaml
+++ b/hub/resourceeditors/monitoring.coreos.com/v1/thanosrulers.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: monitoringcoreoscom-thanosruler-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/monitoring.coreos.com/v1alpha1/alertmanagerconfigs.yaml
+++ b/hub/resourceeditors/monitoring.coreos.com/v1alpha1/alertmanagerconfigs.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: monitoringcoreoscom-alertmanagerconfig-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/networking.k8s.io/v1/ingressclasses.yaml
+++ b/hub/resourceeditors/networking.k8s.io/v1/ingressclasses.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: networkingk8sio-ingressclass-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/networking.k8s.io/v1/ingresses.yaml
+++ b/hub/resourceeditors/networking.k8s.io/v1/ingresses.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: networkingk8sio-ingress-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/networking.k8s.io/v1/networkpolicies.yaml
+++ b/hub/resourceeditors/networking.k8s.io/v1/networkpolicies.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: networkingk8sio-networkpolicy-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/networking.k8s.io/v1beta1/ingressclasses.yaml
+++ b/hub/resourceeditors/networking.k8s.io/v1beta1/ingressclasses.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: networkingk8sio-ingressclass-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/networking.k8s.io/v1beta1/ingresses.yaml
+++ b/hub/resourceeditors/networking.k8s.io/v1beta1/ingresses.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: networkingk8sio-ingress-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/node.k8s.io/v1/runtimeclasses.yaml
+++ b/hub/resourceeditors/node.k8s.io/v1/runtimeclasses.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: nodek8sio-runtimeclass-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/node.k8s.io/v1beta1/runtimeclasses.yaml
+++ b/hub/resourceeditors/node.k8s.io/v1beta1/runtimeclasses.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: nodek8sio-runtimeclass-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/elasticsearchopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/elasticsearchopsrequests.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: opskubedbcom-elasticsearchopsrequest-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/etcdopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/etcdopsrequests.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: opskubedbcom-etcdopsrequest-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/mariadbopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/mariadbopsrequests.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: opskubedbcom-mariadbopsrequest-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/memcachedopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/memcachedopsrequests.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: opskubedbcom-memcachedopsrequest-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/mongodbopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/mongodbopsrequests.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: opskubedbcom-mongodbopsrequest-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/mysqlopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/mysqlopsrequests.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: opskubedbcom-mysqlopsrequest-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/perconaxtradbopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/perconaxtradbopsrequests.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: opskubedbcom-perconaxtradbopsrequest-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/pgbounceropsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/pgbounceropsrequests.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: opskubedbcom-pgbounceropsrequest-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/postgresopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/postgresopsrequests.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: opskubedbcom-postgresopsrequest-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/proxysqlopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/proxysqlopsrequests.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: opskubedbcom-proxysqlopsrequest-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/redisopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/redisopsrequests.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: opskubedbcom-redisopsrequest-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/policy.kubevault.com/v1alpha1/vaultpolicies.yaml
+++ b/hub/resourceeditors/policy.kubevault.com/v1alpha1/vaultpolicies.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: policykubevaultcom-vaultpolicy-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/policy.kubevault.com/v1alpha1/vaultpolicybindings.yaml
+++ b/hub/resourceeditors/policy.kubevault.com/v1alpha1/vaultpolicybindings.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: policykubevaultcom-vaultpolicybinding-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/policy/v1beta1/evictions.yaml
+++ b/hub/resourceeditors/policy/v1beta1/evictions.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: policy-eviction-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/policy/v1beta1/poddisruptionbudgets.yaml
+++ b/hub/resourceeditors/policy/v1beta1/poddisruptionbudgets.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: policy-poddisruptionbudget-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/policy/v1beta1/podsecuritypolicies.yaml
+++ b/hub/resourceeditors/policy/v1beta1/podsecuritypolicies.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: policy-podsecuritypolicy-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/rbac.authorization.k8s.io/v1/clusterrolebindings.yaml
+++ b/hub/resourceeditors/rbac.authorization.k8s.io/v1/clusterrolebindings.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: rbacauthorizationk8sio-clusterrolebinding-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/rbac.authorization.k8s.io/v1/clusterroles.yaml
+++ b/hub/resourceeditors/rbac.authorization.k8s.io/v1/clusterroles.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: rbacauthorizationk8sio-clusterrole-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/rbac.authorization.k8s.io/v1/rolebindings.yaml
+++ b/hub/resourceeditors/rbac.authorization.k8s.io/v1/rolebindings.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: rbacauthorizationk8sio-rolebinding-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/rbac.authorization.k8s.io/v1/roles.yaml
+++ b/hub/resourceeditors/rbac.authorization.k8s.io/v1/roles.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: rbacauthorizationk8sio-role-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/repositories.stash.appscode.com/v1alpha1/snapshots.yaml
+++ b/hub/resourceeditors/repositories.stash.appscode.com/v1alpha1/snapshots.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: repositoriesstashappscodecom-snapshot-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/scheduling.k8s.io/v1/priorityclasses.yaml
+++ b/hub/resourceeditors/scheduling.k8s.io/v1/priorityclasses.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: schedulingk8sio-priorityclass-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/secrets-store.csi.x-k8s.io/v1alpha1/secretproviderclasses.yaml
+++ b/hub/resourceeditors/secrets-store.csi.x-k8s.io/v1alpha1/secretproviderclasses.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: secretsstorecsixk8sio-secretproviderclass-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/secrets-store.csi.x-k8s.io/v1alpha1/secretproviderclasspodstatuses.yaml
+++ b/hub/resourceeditors/secrets-store.csi.x-k8s.io/v1alpha1/secretproviderclasspodstatuses.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: secretsstorecsixk8sio-secretproviderclasspodstatus-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/settings.k8s.io/v1alpha1/podpresets.yaml
+++ b/hub/resourceeditors/settings.k8s.io/v1alpha1/podpresets.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: settingsk8sio-podpreset-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshotclasses.yaml
+++ b/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshotclasses.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: snapshotstoragek8sio-volumesnapshotclass-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshotcontents.yaml
+++ b/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshotcontents.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: snapshotstoragek8sio-volumesnapshotcontent-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshots.yaml
+++ b/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshots.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: snapshotstoragek8sio-volumesnapshot-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/stash.appscode.com/v1alpha1/recoveries.yaml
+++ b/hub/resourceeditors/stash.appscode.com/v1alpha1/recoveries.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: stashappscodecom-recovery-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/stash.appscode.com/v1alpha1/repositories.yaml
+++ b/hub/resourceeditors/stash.appscode.com/v1alpha1/repositories.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: stashappscodecom-repository-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/stash.appscode.com/v1alpha1/restics.yaml
+++ b/hub/resourceeditors/stash.appscode.com/v1alpha1/restics.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: stashappscodecom-restic-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/stash.appscode.com/v1beta1/backupbatches.yaml
+++ b/hub/resourceeditors/stash.appscode.com/v1beta1/backupbatches.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: stashappscodecom-backupbatch-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/stash.appscode.com/v1beta1/backupblueprints.yaml
+++ b/hub/resourceeditors/stash.appscode.com/v1beta1/backupblueprints.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: stashappscodecom-backupblueprint-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/stash.appscode.com/v1beta1/backupconfigurations.yaml
+++ b/hub/resourceeditors/stash.appscode.com/v1beta1/backupconfigurations.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: stashappscodecom-backupconfiguration-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/stash.appscode.com/v1beta1/backupsessions.yaml
+++ b/hub/resourceeditors/stash.appscode.com/v1beta1/backupsessions.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: stashappscodecom-backupsession-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/stash.appscode.com/v1beta1/functions.yaml
+++ b/hub/resourceeditors/stash.appscode.com/v1beta1/functions.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: stashappscodecom-function-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/stash.appscode.com/v1beta1/restorebatches.yaml
+++ b/hub/resourceeditors/stash.appscode.com/v1beta1/restorebatches.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: stashappscodecom-restorebatch-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/stash.appscode.com/v1beta1/restoresessions.yaml
+++ b/hub/resourceeditors/stash.appscode.com/v1beta1/restoresessions.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: stashappscodecom-restoresession-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/stash.appscode.com/v1beta1/tasks.yaml
+++ b/hub/resourceeditors/stash.appscode.com/v1beta1/tasks.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: stashappscodecom-task-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/storage.k8s.io/v1/csidrivers.yaml
+++ b/hub/resourceeditors/storage.k8s.io/v1/csidrivers.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: storagek8sio-csidriver-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/storage.k8s.io/v1/csinodes.yaml
+++ b/hub/resourceeditors/storage.k8s.io/v1/csinodes.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: storagek8sio-csinode-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/storage.k8s.io/v1/storageclasses.yaml
+++ b/hub/resourceeditors/storage.k8s.io/v1/storageclasses.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: storagek8sio-storageclass-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/storage.k8s.io/v1/volumeattachments.yaml
+++ b/hub/resourceeditors/storage.k8s.io/v1/volumeattachments.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: storagek8sio-volumeattachment-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/storage.k8s.io/v1beta1/csistoragecapacities.yaml
+++ b/hub/resourceeditors/storage.k8s.io/v1beta1/csistoragecapacities.yaml
@@ -19,4 +19,4 @@ spec:
     editor:
       name: storagek8sio-csistoragecapacity-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/voyager.appscode.com/v1/ingresses.yaml
+++ b/hub/resourceeditors/voyager.appscode.com/v1/ingresses.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: voyagerappscodecom-ingress-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6

--- a/hub/resourceeditors/voyager.appscode.com/v1beta1/ingresses.yaml
+++ b/hub/resourceeditors/voyager.appscode.com/v1beta1/ingresses.yaml
@@ -24,4 +24,4 @@ spec:
     editor:
       name: voyagerappscodecom-ingress-editor
       url: https://bundles.byte.builders/ui/
-      version: v0.4.3
+      version: v0.4.6


### PR DESCRIPTION
ProductLine: ByteBuilders
Release: v2022.06.13
Release-tracker: https://github.com/bytebuilders/CHANGELOG/pull/26
Signed-off-by: 1gtm <1gtm@appscode.com>