### PR TITLE
Prepare for release v0.17.3

### DIFF
--- a/hub/resourceeditors/acme.cert-manager.io/v1/challenges.yaml
+++ b/hub/resourceeditors/acme.cert-manager.io/v1/challenges.yaml
@@ -35,4 +35,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/acme.cert-manager.io/v1/orders.yaml
+++ b/hub/resourceeditors/acme.cert-manager.io/v1/orders.yaml
@@ -35,4 +35,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/addons.cluster.x-k8s.io/v1beta1/clusterresourcesetbindings.yaml
+++ b/hub/resourceeditors/addons.cluster.x-k8s.io/v1beta1/clusterresourcesetbindings.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/addons.cluster.x-k8s.io/v1beta1/clusterresourcesets.yaml
+++ b/hub/resourceeditors/addons.cluster.x-k8s.io/v1beta1/clusterresourcesets.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations.yaml
+++ b/hub/resourceeditors/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/admissionregistration.k8s.io/v1/validatingwebhookconfigurations.yaml
+++ b/hub/resourceeditors/admissionregistration.k8s.io/v1/validatingwebhookconfigurations.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/apiextensions.k8s.io/v1/customresourcedefinitions.yaml
+++ b/hub/resourceeditors/apiextensions.k8s.io/v1/customresourcedefinitions.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/apiregistration.k8s.io/v1/apiservices.yaml
+++ b/hub/resourceeditors/apiregistration.k8s.io/v1/apiservices.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/app.k8s.io/v1beta1/applications.yaml
+++ b/hub/resourceeditors/app.k8s.io/v1beta1/applications.yaml
@@ -22,6 +22,6 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15
     instanceLabelPaths:
     - spec.selector.matchLabels

--- a/hub/resourceeditors/appcatalog.appscode.com/v1alpha1/appbindings.yaml
+++ b/hub/resourceeditors/appcatalog.appscode.com/v1alpha1/appbindings.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/apps/v1/daemonsets.yaml
+++ b/hub/resourceeditors/apps/v1/daemonsets.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/apps/v1/deployments.yaml
+++ b/hub/resourceeditors/apps/v1/deployments.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/apps/v1/replicasets.yaml
+++ b/hub/resourceeditors/apps/v1/replicasets.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/apps/v1/statefulsets.yaml
+++ b/hub/resourceeditors/apps/v1/statefulsets.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/auditor.appscode.com/v1alpha1/siteinfos.yaml
+++ b/hub/resourceeditors/auditor.appscode.com/v1alpha1/siteinfos.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/auditregistration.k8s.io/v1alpha1/auditsinks.yaml
+++ b/hub/resourceeditors/auditregistration.k8s.io/v1alpha1/auditsinks.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/autoscaling.k8s.io/v1/verticalpodautoscalercheckpoints.yaml
+++ b/hub/resourceeditors/autoscaling.k8s.io/v1/verticalpodautoscalercheckpoints.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/autoscaling.k8s.io/v1/verticalpodautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.k8s.io/v1/verticalpodautoscalers.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/elasticsearchautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/elasticsearchautoscalers.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/etcdautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/etcdautoscalers.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mariadbautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mariadbautoscalers.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/memcachedautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/memcachedautoscalers.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mongodbautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mongodbautoscalers.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mysqlautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mysqlautoscalers.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/perconaxtradbautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/perconaxtradbautoscalers.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/pgbouncerautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/pgbouncerautoscalers.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/postgresautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/postgresautoscalers.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/proxysqlautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/proxysqlautoscalers.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/redisautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/redisautoscalers.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/redissentinelautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/redissentinelautoscalers.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/autoscaling/v2beta2/horizontalpodautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling/v2beta2/horizontalpodautoscalers.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/batch/v1/cronjobs.yaml
+++ b/hub/resourceeditors/batch/v1/cronjobs.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/batch/v1/jobs.yaml
+++ b/hub/resourceeditors/batch/v1/jobs.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/batch/v1beta1/cronjobs.yaml
+++ b/hub/resourceeditors/batch/v1beta1/cronjobs.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/bootstrap.cluster.x-k8s.io/v1beta2/eksconfigs.yaml
+++ b/hub/resourceeditors/bootstrap.cluster.x-k8s.io/v1beta2/eksconfigs.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/bootstrap.cluster.x-k8s.io/v1beta2/eksconfigtemplates.yaml
+++ b/hub/resourceeditors/bootstrap.cluster.x-k8s.io/v1beta2/eksconfigtemplates.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/elasticsearchversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/elasticsearchversions.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/etcdversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/etcdversions.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/kafkaversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/kafkaversions.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mariadbversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mariadbversions.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/memcachedversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/memcachedversions.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mongodbversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mongodbversions.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mysqlversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mysqlversions.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/perconaxtradbversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/perconaxtradbversions.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/pgbouncerversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/pgbouncerversions.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/postgresversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/postgresversions.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/proxysqlversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/proxysqlversions.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/redisversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/redisversions.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/catalog.kubevault.com/v1alpha1/vaultserverversions.yaml
+++ b/hub/resourceeditors/catalog.kubevault.com/v1alpha1/vaultserverversions.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/cert-manager.io/v1/certificaterequests.yaml
+++ b/hub/resourceeditors/cert-manager.io/v1/certificaterequests.yaml
@@ -35,4 +35,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/cert-manager.io/v1/certificates.yaml
+++ b/hub/resourceeditors/cert-manager.io/v1/certificates.yaml
@@ -35,4 +35,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/cert-manager.io/v1/clusterissuers.yaml
+++ b/hub/resourceeditors/cert-manager.io/v1/clusterissuers.yaml
@@ -35,4 +35,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/cert-manager.io/v1/issuers.yaml
+++ b/hub/resourceeditors/cert-manager.io/v1/issuers.yaml
@@ -35,4 +35,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/certificates.k8s.io/v1/certificatesigningrequests.yaml
+++ b/hub/resourceeditors/certificates.k8s.io/v1/certificatesigningrequests.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/certificates.k8s.io/v1beta1/certificatesigningrequests.yaml
+++ b/hub/resourceeditors/certificates.k8s.io/v1beta1/certificatesigningrequests.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/charts.x-helm.dev/v1alpha1/chartpresets.yaml
+++ b/hub/resourceeditors/charts.x-helm.dev/v1alpha1/chartpresets.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/charts.x-helm.dev/v1alpha1/clusterchartpresets.yaml
+++ b/hub/resourceeditors/charts.x-helm.dev/v1alpha1/clusterchartpresets.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/cluster.x-k8s.io/v1alpha3/machines.yaml
+++ b/hub/resourceeditors/cluster.x-k8s.io/v1alpha3/machines.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/cluster.x-k8s.io/v1alpha3/machinesets.yaml
+++ b/hub/resourceeditors/cluster.x-k8s.io/v1alpha3/machinesets.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/cluster.x-k8s.io/v1beta1/clusterclasses.yaml
+++ b/hub/resourceeditors/cluster.x-k8s.io/v1beta1/clusterclasses.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/cluster.x-k8s.io/v1beta1/clusters.yaml
+++ b/hub/resourceeditors/cluster.x-k8s.io/v1beta1/clusters.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machinedeployments.yaml
+++ b/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machinedeployments.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machinehealthchecks.yaml
+++ b/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machinehealthchecks.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machinepools.yaml
+++ b/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machinepools.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machines.yaml
+++ b/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machines.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machinesets.yaml
+++ b/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machinesets.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/config.gatekeeper.sh/v1alpha1/configs.yaml
+++ b/hub/resourceeditors/config.gatekeeper.sh/v1alpha1/configs.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/controlplane.cluster.x-k8s.io/v1beta2/awsmanagedcontrolplanes.yaml
+++ b/hub/resourceeditors/controlplane.cluster.x-k8s.io/v1beta2/awsmanagedcontrolplanes.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/coordination.k8s.io/v1/leases.yaml
+++ b/hub/resourceeditors/coordination.k8s.io/v1/leases.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/genericresources.yaml
+++ b/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/genericresources.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/genericresourceservices.yaml
+++ b/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/genericresourceservices.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/podviews.yaml
+++ b/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/podviews.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/resourcesummaries.yaml
+++ b/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/resourcesummaries.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/core/v1/bindings.yaml
+++ b/hub/resourceeditors/core/v1/bindings.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/core/v1/componentstatuses.yaml
+++ b/hub/resourceeditors/core/v1/componentstatuses.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/core/v1/configmaps.yaml
+++ b/hub/resourceeditors/core/v1/configmaps.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/core/v1/endpoints.yaml
+++ b/hub/resourceeditors/core/v1/endpoints.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/core/v1/ephemeralcontainers.yaml
+++ b/hub/resourceeditors/core/v1/ephemeralcontainers.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/core/v1/events.yaml
+++ b/hub/resourceeditors/core/v1/events.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/core/v1/limitranges.yaml
+++ b/hub/resourceeditors/core/v1/limitranges.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/core/v1/namespaces.yaml
+++ b/hub/resourceeditors/core/v1/namespaces.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/core/v1/nodes.yaml
+++ b/hub/resourceeditors/core/v1/nodes.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/core/v1/persistentvolumeclaims.yaml
+++ b/hub/resourceeditors/core/v1/persistentvolumeclaims.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/core/v1/persistentvolumes.yaml
+++ b/hub/resourceeditors/core/v1/persistentvolumes.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/core/v1/pods.yaml
+++ b/hub/resourceeditors/core/v1/pods.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/core/v1/podstatusresults.yaml
+++ b/hub/resourceeditors/core/v1/podstatusresults.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/core/v1/podtemplates.yaml
+++ b/hub/resourceeditors/core/v1/podtemplates.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/core/v1/rangeallocations.yaml
+++ b/hub/resourceeditors/core/v1/rangeallocations.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/core/v1/replicationcontrollers.yaml
+++ b/hub/resourceeditors/core/v1/replicationcontrollers.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/core/v1/resourcequota.yaml
+++ b/hub/resourceeditors/core/v1/resourcequota.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/core/v1/resourcequotas.yaml
+++ b/hub/resourceeditors/core/v1/resourcequotas.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/core/v1/secrets.yaml
+++ b/hub/resourceeditors/core/v1/secrets.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/core/v1/serviceaccounts.yaml
+++ b/hub/resourceeditors/core/v1/serviceaccounts.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/core/v1/services.yaml
+++ b/hub/resourceeditors/core/v1/services.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/dashboard.kubedb.com/v1alpha1/elasticsearchdashboards.yaml
+++ b/hub/resourceeditors/dashboard.kubedb.com/v1alpha1/elasticsearchdashboards.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/discovery.k8s.io/v1/endpointslice.yaml
+++ b/hub/resourceeditors/discovery.k8s.io/v1/endpointslice.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/discovery.k8s.io/v1beta1/endpointslice.yaml
+++ b/hub/resourceeditors/discovery.k8s.io/v1beta1/endpointslice.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/discovery.k8s.io/v1beta1/endpointslices.yaml
+++ b/hub/resourceeditors/discovery.k8s.io/v1beta1/endpointslices.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/drivers.x-helm.dev/v1alpha1/appreleases.yaml
+++ b/hub/resourceeditors/drivers.x-helm.dev/v1alpha1/appreleases.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/engine.kubevault.com/v1alpha1/awsroles.yaml
+++ b/hub/resourceeditors/engine.kubevault.com/v1alpha1/awsroles.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/engine.kubevault.com/v1alpha1/azureroles.yaml
+++ b/hub/resourceeditors/engine.kubevault.com/v1alpha1/azureroles.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/engine.kubevault.com/v1alpha1/elasticsearchroles.yaml
+++ b/hub/resourceeditors/engine.kubevault.com/v1alpha1/elasticsearchroles.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/engine.kubevault.com/v1alpha1/gcproles.yaml
+++ b/hub/resourceeditors/engine.kubevault.com/v1alpha1/gcproles.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/engine.kubevault.com/v1alpha1/mariadbroles.yaml
+++ b/hub/resourceeditors/engine.kubevault.com/v1alpha1/mariadbroles.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/engine.kubevault.com/v1alpha1/mongodbroles.yaml
+++ b/hub/resourceeditors/engine.kubevault.com/v1alpha1/mongodbroles.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/engine.kubevault.com/v1alpha1/mysqlroles.yaml
+++ b/hub/resourceeditors/engine.kubevault.com/v1alpha1/mysqlroles.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/engine.kubevault.com/v1alpha1/postgresroles.yaml
+++ b/hub/resourceeditors/engine.kubevault.com/v1alpha1/postgresroles.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/engine.kubevault.com/v1alpha1/redisroles.yaml
+++ b/hub/resourceeditors/engine.kubevault.com/v1alpha1/redisroles.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretaccessrequests.yaml
+++ b/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretaccessrequests.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretengines.yaml
+++ b/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretengines.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretrolebindings.yaml
+++ b/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretrolebindings.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/events.k8s.io/v1/events.yaml
+++ b/hub/resourceeditors/events.k8s.io/v1/events.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/events.k8s.io/v1beta1/events.yaml
+++ b/hub/resourceeditors/events.k8s.io/v1beta1/events.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/expansion.gatekeeper.sh/v1alpha1/expansiontemplate.yaml
+++ b/hub/resourceeditors/expansion.gatekeeper.sh/v1alpha1/expansiontemplate.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/extensions/v1beta1/daemonsets.yaml
+++ b/hub/resourceeditors/extensions/v1beta1/daemonsets.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/extensions/v1beta1/deployments.yaml
+++ b/hub/resourceeditors/extensions/v1beta1/deployments.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/extensions/v1beta1/ingresses.yaml
+++ b/hub/resourceeditors/extensions/v1beta1/ingresses.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/extensions/v1beta1/networkpolicies.yaml
+++ b/hub/resourceeditors/extensions/v1beta1/networkpolicies.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/extensions/v1beta1/podsecuritypolicies.yaml
+++ b/hub/resourceeditors/extensions/v1beta1/podsecuritypolicies.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/extensions/v1beta1/replicasets.yaml
+++ b/hub/resourceeditors/extensions/v1beta1/replicasets.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/extensions/v1beta1/scales.yaml
+++ b/hub/resourceeditors/extensions/v1beta1/scales.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/external-dns.appscode.com/v1alpha1/externaldns.yaml
+++ b/hub/resourceeditors/external-dns.appscode.com/v1alpha1/externaldns.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1alpha1/flowschemas.yaml
+++ b/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1alpha1/flowschemas.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1alpha1/prioritylevelconfigurations.yaml
+++ b/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1alpha1/prioritylevelconfigurations.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1beta1/flowschemas.yaml
+++ b/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1beta1/flowschemas.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1beta1/prioritylevelconfigurations.yaml
+++ b/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1beta1/prioritylevelconfigurations.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/helm.toolkit.fluxcd.io/v2beta1/helmreleases.yaml
+++ b/hub/resourceeditors/helm.toolkit.fluxcd.io/v2beta1/helmreleases.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta1/imagepolicies.yaml
+++ b/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta1/imagepolicies.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta1/imagerepositories.yaml
+++ b/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta1/imagerepositories.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta1/imageupdateautomations.yaml
+++ b/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta1/imageupdateautomations.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/imagepolicy.k8s.io/v1alpha1/imagereviews.yaml
+++ b/hub/resourceeditors/imagepolicy.k8s.io/v1alpha1/imagereviews.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha3/azureserviceprincipals.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha3/azureserviceprincipals.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha3/azuresystemassignedidentites.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha3/azuresystemassignedidentites.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha3/azureuserassignedidentites.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha3/azureuserassignedidentites.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azureclusteridentities.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azureclusteridentities.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azureclusters.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azureclusters.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azureclustertemplates.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azureclustertemplates.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremachinepoolmachines.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremachinepoolmachines.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremachinepools.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremachinepools.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremachines.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremachines.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremachinetemplates.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremachinetemplates.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedclusters.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedclusters.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedcontrolplanes.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedcontrolplanes.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedmachinepools.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedmachinepools.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclustercontrolleridentities.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclustercontrolleridentities.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclusterroleidentities.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclusterroleidentities.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclusters.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclusters.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclusterstaticidentities.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclusterstaticidentities.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclustertemplates.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclustertemplates.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsfargateprofiles.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsfargateprofiles.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmachinepools.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmachinepools.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmachines.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmachines.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmachinetemplates.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmachinetemplates.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmanagedclusters.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmanagedclusters.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmanagedmachinepools.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmanagedmachinepools.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/internal.apiserver.k8s.io/v1alpha1/storageversions.yaml
+++ b/hub/resourceeditors/internal.apiserver.k8s.io/v1alpha1/storageversions.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ipam.cluster.x-k8s.io/v1alpha1/ipaddressclaims.yaml
+++ b/hub/resourceeditors/ipam.cluster.x-k8s.io/v1alpha1/ipaddressclaims.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ipam.cluster.x-k8s.io/v1alpha1/ipaddresses.yaml
+++ b/hub/resourceeditors/ipam.cluster.x-k8s.io/v1alpha1/ipaddresses.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/kubedb.com/v1alpha2/elasticsearches.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/elasticsearches.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-edit
         icons:
         - src: https://cdn.appscode.com/k8s/icons/stash.appscode.com/backupconfigurations.svg
@@ -42,7 +42,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://cdn.appscode.com/k8s/icons/stash.appscode.com/restoresessions.svg
@@ -57,7 +57,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/buy-upgrade.png
@@ -70,7 +70,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/restart.png
@@ -85,7 +85,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/resize-horizontal.png
@@ -98,7 +98,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/resize-vertical.png
@@ -111,7 +111,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/expand.png
@@ -128,7 +128,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/networking.svg
@@ -141,7 +141,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-edit
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/monitoring.svg
@@ -155,11 +155,11 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15
     options:
       name: kubedbcom-elasticsearch-editor-options
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/kubedb.com/v1alpha2/etcds.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/etcds.yaml
@@ -27,11 +27,11 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15
     options:
       name: kubedbcom-etcd-editor-options
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/kubedb.com/v1alpha2/kafkas.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/kafkas.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-edit
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/monitoring.svg
@@ -43,11 +43,11 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15
     options:
       name: kubedbcom-kafka-editor-options
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/kubedb.com/v1alpha2/mariadbs.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/mariadbs.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-edit
         icons:
         - src: https://cdn.appscode.com/k8s/icons/stash.appscode.com/backupconfigurations.svg
@@ -42,7 +42,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://cdn.appscode.com/k8s/icons/stash.appscode.com/restoresessions.svg
@@ -57,7 +57,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/buy-upgrade.png
@@ -70,7 +70,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/restart.png
@@ -83,7 +83,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/config.svg
@@ -100,7 +100,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/resize-horizontal.png
@@ -113,7 +113,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/resize-vertical.png
@@ -126,7 +126,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/expand.png
@@ -141,7 +141,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/networking.svg
@@ -154,7 +154,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-edit
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/monitoring.svg
@@ -168,11 +168,11 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15
     options:
       name: kubedbcom-mariadb-editor-options
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/kubedb.com/v1alpha2/memcacheds.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/memcacheds.yaml
@@ -27,11 +27,11 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15
     options:
       name: kubedbcom-memcached-editor-options
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/kubedb.com/v1alpha2/mongodbs.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/mongodbs.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-edit
         icons:
         - src: https://cdn.appscode.com/k8s/icons/stash.appscode.com/backupconfigurations.svg
@@ -42,7 +42,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://cdn.appscode.com/k8s/icons/stash.appscode.com/restoresessions.svg
@@ -57,7 +57,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/buy-upgrade.png
@@ -70,7 +70,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/restart.png
@@ -83,7 +83,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/config.svg
@@ -100,7 +100,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/resize-horizontal.png
@@ -113,7 +113,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/resize-vertical.png
@@ -126,7 +126,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/expand.png
@@ -141,7 +141,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/networking.svg
@@ -154,7 +154,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-edit
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/monitoring.svg
@@ -168,11 +168,11 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15
     options:
       name: kubedbcom-mongodb-editor-options
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/kubedb.com/v1alpha2/mysqls.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/mysqls.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-edit
         icons:
         - src: https://cdn.appscode.com/k8s/icons/stash.appscode.com/backupconfigurations.svg
@@ -42,7 +42,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://cdn.appscode.com/k8s/icons/stash.appscode.com/restoresessions.svg
@@ -57,7 +57,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/buy-upgrade.png
@@ -70,7 +70,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/restart.png
@@ -83,7 +83,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/config.svg
@@ -100,7 +100,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/resize-horizontal.png
@@ -113,7 +113,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/resize-vertical.png
@@ -126,7 +126,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/expand.png
@@ -141,7 +141,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/networking.svg
@@ -154,7 +154,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-edit
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/monitoring.svg
@@ -168,11 +168,11 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15
     options:
       name: kubedbcom-mysql-editor-options
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/kubedb.com/v1alpha2/perconaxtradbs.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/perconaxtradbs.yaml
@@ -27,11 +27,11 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15
     options:
       name: kubedbcom-perconaxtradb-editor-options
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/kubedb.com/v1alpha2/pgbouncers.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/pgbouncers.yaml
@@ -27,11 +27,11 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15
     options:
       name: kubedbcom-pgbouncer-editor-options
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/kubedb.com/v1alpha2/postgreses.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/postgreses.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-edit
         icons:
         - src: https://cdn.appscode.com/k8s/icons/stash.appscode.com/backupconfigurations.svg
@@ -42,7 +42,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://cdn.appscode.com/k8s/icons/stash.appscode.com/restoresessions.svg
@@ -57,7 +57,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/buy-upgrade.png
@@ -70,7 +70,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/restart.png
@@ -83,7 +83,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/config.svg
@@ -100,7 +100,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/resize-horizontal.png
@@ -113,7 +113,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/resize-vertical.png
@@ -126,7 +126,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/expand.png
@@ -141,7 +141,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/networking.svg
@@ -154,7 +154,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-edit
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/monitoring.svg
@@ -168,11 +168,11 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15
     options:
       name: kubedbcom-postgres-editor-options
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/kubedb.com/v1alpha2/proxysqls.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/proxysqls.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/buy-upgrade.png
@@ -42,7 +42,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/restart.png
@@ -55,7 +55,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/config.svg
@@ -70,7 +70,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/resize-horizontal.png
@@ -83,7 +83,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/resize-vertical.png
@@ -98,7 +98,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/networking.svg
@@ -111,7 +111,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-edit
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/monitoring.svg
@@ -125,11 +125,11 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15
     options:
       name: kubedbcom-proxysql-editor-options
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/kubedb.com/v1alpha2/redises.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/redises.yaml
@@ -29,7 +29,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-edit
         icons:
         - src: https://cdn.appscode.com/k8s/icons/stash.appscode.com/backupconfigurations.svg
@@ -42,7 +42,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://cdn.appscode.com/k8s/icons/stash.appscode.com/restoresessions.svg
@@ -57,7 +57,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/buy-upgrade.png
@@ -70,7 +70,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/restart.png
@@ -83,7 +83,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/config.svg
@@ -100,7 +100,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/resize-horizontal.png
@@ -113,7 +113,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/resize-vertical.png
@@ -126,7 +126,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://img.icons8.com/plasticine/512/expand.png
@@ -141,7 +141,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-create
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/networking.svg
@@ -154,7 +154,7 @@ spec:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
             name: bytebuilders-ui
-          version: v0.4.14
+          version: v0.4.15
         flow: standalone-edit
         icons:
         - src: https://cdn.appscode.com/k8s/icons/menu/monitoring.svg
@@ -168,11 +168,11 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15
     options:
       name: kubedbcom-redis-editor-options
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/kubedb.com/v1alpha2/redissentinels.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/redissentinels.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/kubevault.com/v1alpha2/vaultservers.yaml
+++ b/hub/resourceeditors/kubevault.com/v1alpha2/vaultservers.yaml
@@ -27,11 +27,11 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15
     options:
       name: kubevaultcom-vaultserver-editor-options
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/kustomize.toolkit.fluxcd.io/v1beta2/kustomizations.yaml
+++ b/hub/resourceeditors/kustomize.toolkit.fluxcd.io/v1beta2/kustomizations.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/match.gatekeeper.sh/match/matchcrd.yaml
+++ b/hub/resourceeditors/match.gatekeeper.sh/match/matchcrd.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/meta.appscode.com/v1alpha1/resourcedescriptors.yaml
+++ b/hub/resourceeditors/meta.appscode.com/v1alpha1/resourcedescriptors.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/menuoutlines.yaml
+++ b/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/menuoutlines.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/menus.yaml
+++ b/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/menus.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourceblockdefinitions.yaml
+++ b/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourceblockdefinitions.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcedescriptors.yaml
+++ b/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcedescriptors.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcelayouts.yaml
+++ b/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcelayouts.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourceoutlines.yaml
+++ b/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourceoutlines.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcetabledefinitions.yaml
+++ b/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcetabledefinitions.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/metrics.appscode.com/v1alpha1/metricsconfigurations.yaml
+++ b/hub/resourceeditors/metrics.appscode.com/v1alpha1/metricsconfigurations.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/monitoring.coreos.com/v1/alertmanagers.yaml
+++ b/hub/resourceeditors/monitoring.coreos.com/v1/alertmanagers.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/monitoring.coreos.com/v1/podmonitors.yaml
+++ b/hub/resourceeditors/monitoring.coreos.com/v1/podmonitors.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/monitoring.coreos.com/v1/probes.yaml
+++ b/hub/resourceeditors/monitoring.coreos.com/v1/probes.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/monitoring.coreos.com/v1/prometheuses.yaml
+++ b/hub/resourceeditors/monitoring.coreos.com/v1/prometheuses.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/monitoring.coreos.com/v1/prometheusrules.yaml
+++ b/hub/resourceeditors/monitoring.coreos.com/v1/prometheusrules.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/monitoring.coreos.com/v1/servicemonitors.yaml
+++ b/hub/resourceeditors/monitoring.coreos.com/v1/servicemonitors.yaml
@@ -27,6 +27,6 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15
     instanceLabelPaths:
     - spec.selector.matchLabels

--- a/hub/resourceeditors/monitoring.coreos.com/v1/thanosrulers.yaml
+++ b/hub/resourceeditors/monitoring.coreos.com/v1/thanosrulers.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/monitoring.coreos.com/v1alpha1/alertmanagerconfigs.yaml
+++ b/hub/resourceeditors/monitoring.coreos.com/v1alpha1/alertmanagerconfigs.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/mutations.gatekeeper.sh/v1/assign.yaml
+++ b/hub/resourceeditors/mutations.gatekeeper.sh/v1/assign.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/mutations.gatekeeper.sh/v1/assignmetadata.yaml
+++ b/hub/resourceeditors/mutations.gatekeeper.sh/v1/assignmetadata.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/mutations.gatekeeper.sh/v1/modifyset.yaml
+++ b/hub/resourceeditors/mutations.gatekeeper.sh/v1/modifyset.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/mutations.gatekeeper.sh/v1alpha1/assignimage.yaml
+++ b/hub/resourceeditors/mutations.gatekeeper.sh/v1alpha1/assignimage.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/networking.k8s.io/v1/ingressclasses.yaml
+++ b/hub/resourceeditors/networking.k8s.io/v1/ingressclasses.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/networking.k8s.io/v1/ingresses.yaml
+++ b/hub/resourceeditors/networking.k8s.io/v1/ingresses.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/networking.k8s.io/v1/networkpolicies.yaml
+++ b/hub/resourceeditors/networking.k8s.io/v1/networkpolicies.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/networking.k8s.io/v1beta1/ingressclasses.yaml
+++ b/hub/resourceeditors/networking.k8s.io/v1beta1/ingressclasses.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/networking.k8s.io/v1beta1/ingresses.yaml
+++ b/hub/resourceeditors/networking.k8s.io/v1beta1/ingresses.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/node.k8s.io/v1/runtimeclasses.yaml
+++ b/hub/resourceeditors/node.k8s.io/v1/runtimeclasses.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/node.k8s.io/v1beta1/runtimeclasses.yaml
+++ b/hub/resourceeditors/node.k8s.io/v1beta1/runtimeclasses.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta1/alerts.yaml
+++ b/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta1/alerts.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta1/providers.yaml
+++ b/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta1/providers.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta1/receivers.yaml
+++ b/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta1/receivers.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/openviz.dev/v1alpha1/grafanadashboards.yaml
+++ b/hub/resourceeditors/openviz.dev/v1alpha1/grafanadashboards.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/openviz.dev/v1alpha1/grafanadashboardtemplates.yaml
+++ b/hub/resourceeditors/openviz.dev/v1alpha1/grafanadashboardtemplates.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/openviz.dev/v1alpha1/grafanadatasources.yaml
+++ b/hub/resourceeditors/openviz.dev/v1alpha1/grafanadatasources.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/elasticsearchopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/elasticsearchopsrequests.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/etcdopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/etcdopsrequests.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/mariadbopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/mariadbopsrequests.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/memcachedopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/memcachedopsrequests.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/mongodbopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/mongodbopsrequests.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/mysqlopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/mysqlopsrequests.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/perconaxtradbopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/perconaxtradbopsrequests.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/pgbounceropsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/pgbounceropsrequests.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/postgresopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/postgresopsrequests.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/proxysqlopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/proxysqlopsrequests.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/redisopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/redisopsrequests.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/redissentinelopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/redissentinelopsrequests.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ops.kubevault.com/v1alpha1/vaultopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubevault.com/v1alpha1/vaultopsrequests.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/policy.kubevault.com/v1alpha1/vaultpolicies.yaml
+++ b/hub/resourceeditors/policy.kubevault.com/v1alpha1/vaultpolicies.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/policy.kubevault.com/v1alpha1/vaultpolicybindings.yaml
+++ b/hub/resourceeditors/policy.kubevault.com/v1alpha1/vaultpolicybindings.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/policy/v1beta1/evictions.yaml
+++ b/hub/resourceeditors/policy/v1beta1/evictions.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/policy/v1beta1/poddisruptionbudgets.yaml
+++ b/hub/resourceeditors/policy/v1beta1/poddisruptionbudgets.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/policy/v1beta1/podsecuritypolicies.yaml
+++ b/hub/resourceeditors/policy/v1beta1/podsecuritypolicies.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/postgres.kubedb.com/v1alpha1/publishers.yaml
+++ b/hub/resourceeditors/postgres.kubedb.com/v1alpha1/publishers.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/postgres.kubedb.com/v1alpha1/subscribers.yaml
+++ b/hub/resourceeditors/postgres.kubedb.com/v1alpha1/subscribers.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/products.x-helm.dev/v1alpha1/plans.yaml
+++ b/hub/resourceeditors/products.x-helm.dev/v1alpha1/plans.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/products.x-helm.dev/v1alpha1/products.yaml
+++ b/hub/resourceeditors/products.x-helm.dev/v1alpha1/products.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/rbac.authorization.k8s.io/v1/clusterrolebindings.yaml
+++ b/hub/resourceeditors/rbac.authorization.k8s.io/v1/clusterrolebindings.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/rbac.authorization.k8s.io/v1/clusterroles.yaml
+++ b/hub/resourceeditors/rbac.authorization.k8s.io/v1/clusterroles.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/rbac.authorization.k8s.io/v1/rolebindings.yaml
+++ b/hub/resourceeditors/rbac.authorization.k8s.io/v1/rolebindings.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/rbac.authorization.k8s.io/v1/roles.yaml
+++ b/hub/resourceeditors/rbac.authorization.k8s.io/v1/roles.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/releases.x-helm.dev/v1alpha1/bundles.yaml
+++ b/hub/resourceeditors/releases.x-helm.dev/v1alpha1/bundles.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/releases.x-helm.dev/v1alpha1/orders.yaml
+++ b/hub/resourceeditors/releases.x-helm.dev/v1alpha1/orders.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/repositories.stash.appscode.com/v1alpha1/snapshots.yaml
+++ b/hub/resourceeditors/repositories.stash.appscode.com/v1alpha1/snapshots.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/runtime.cluster.x-k8s.io/v1alpha1/extensionconfigs.yaml
+++ b/hub/resourceeditors/runtime.cluster.x-k8s.io/v1alpha1/extensionconfigs.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/scheduling.k8s.io/v1/priorityclasses.yaml
+++ b/hub/resourceeditors/scheduling.k8s.io/v1/priorityclasses.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/schema.kubedb.com/v1alpha1/mariadbdatabases.yaml
+++ b/hub/resourceeditors/schema.kubedb.com/v1alpha1/mariadbdatabases.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/schema.kubedb.com/v1alpha1/mongodbdatabases.yaml
+++ b/hub/resourceeditors/schema.kubedb.com/v1alpha1/mongodbdatabases.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/schema.kubedb.com/v1alpha1/mysqldatabases.yaml
+++ b/hub/resourceeditors/schema.kubedb.com/v1alpha1/mysqldatabases.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/schema.kubedb.com/v1alpha1/postgresdatabases.yaml
+++ b/hub/resourceeditors/schema.kubedb.com/v1alpha1/postgresdatabases.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/secrets-store.csi.x-k8s.io/v1alpha1/secretproviderclasses.yaml
+++ b/hub/resourceeditors/secrets-store.csi.x-k8s.io/v1alpha1/secretproviderclasses.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/secrets-store.csi.x-k8s.io/v1alpha1/secretproviderclasspodstatuses.yaml
+++ b/hub/resourceeditors/secrets-store.csi.x-k8s.io/v1alpha1/secretproviderclasspodstatuses.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/settings.k8s.io/v1alpha1/podpresets.yaml
+++ b/hub/resourceeditors/settings.k8s.io/v1alpha1/podpresets.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshotclasses.yaml
+++ b/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshotclasses.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshotcontents.yaml
+++ b/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshotcontents.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshots.yaml
+++ b/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshots.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/buckets.yaml
+++ b/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/buckets.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/gitrepositories.yaml
+++ b/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/gitrepositories.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/helmcharts.yaml
+++ b/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/helmcharts.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/helmrepositories.yaml
+++ b/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/helmrepositories.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/ocirepositories.yaml
+++ b/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/ocirepositories.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/stash.appscode.com/v1alpha1/recoveries.yaml
+++ b/hub/resourceeditors/stash.appscode.com/v1alpha1/recoveries.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/stash.appscode.com/v1alpha1/repositories.yaml
+++ b/hub/resourceeditors/stash.appscode.com/v1alpha1/repositories.yaml
@@ -27,11 +27,11 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15
     options:
       name: stashappscodecom-repository-editor-options
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/stash.appscode.com/v1alpha1/restics.yaml
+++ b/hub/resourceeditors/stash.appscode.com/v1alpha1/restics.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/stash.appscode.com/v1beta1/backupbatches.yaml
+++ b/hub/resourceeditors/stash.appscode.com/v1beta1/backupbatches.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/stash.appscode.com/v1beta1/backupblueprints.yaml
+++ b/hub/resourceeditors/stash.appscode.com/v1beta1/backupblueprints.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/stash.appscode.com/v1beta1/backupconfigurations.yaml
+++ b/hub/resourceeditors/stash.appscode.com/v1beta1/backupconfigurations.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/stash.appscode.com/v1beta1/backupsessions.yaml
+++ b/hub/resourceeditors/stash.appscode.com/v1beta1/backupsessions.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/stash.appscode.com/v1beta1/functions.yaml
+++ b/hub/resourceeditors/stash.appscode.com/v1beta1/functions.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/stash.appscode.com/v1beta1/restorebatches.yaml
+++ b/hub/resourceeditors/stash.appscode.com/v1beta1/restorebatches.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/stash.appscode.com/v1beta1/restoresessions.yaml
+++ b/hub/resourceeditors/stash.appscode.com/v1beta1/restoresessions.yaml
@@ -27,11 +27,11 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15
     options:
       name: stashappscodecom-restoresession-editor-options
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/stash.appscode.com/v1beta1/tasks.yaml
+++ b/hub/resourceeditors/stash.appscode.com/v1beta1/tasks.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/status.gatekeeper.sh/v1beta1/constraintpodstatuses.yaml
+++ b/hub/resourceeditors/status.gatekeeper.sh/v1beta1/constraintpodstatuses.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/status.gatekeeper.sh/v1beta1/constrainttemplatepodstatuses.yaml
+++ b/hub/resourceeditors/status.gatekeeper.sh/v1beta1/constrainttemplatepodstatuses.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/status.gatekeeper.sh/v1beta1/expansiontemplatepodstatuses.yaml
+++ b/hub/resourceeditors/status.gatekeeper.sh/v1beta1/expansiontemplatepodstatuses.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/status.gatekeeper.sh/v1beta1/mutatorpodstatuses.yaml
+++ b/hub/resourceeditors/status.gatekeeper.sh/v1beta1/mutatorpodstatuses.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/storage.k8s.io/v1/csidrivers.yaml
+++ b/hub/resourceeditors/storage.k8s.io/v1/csidrivers.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/storage.k8s.io/v1/csinodes.yaml
+++ b/hub/resourceeditors/storage.k8s.io/v1/csinodes.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/storage.k8s.io/v1/storageclasses.yaml
+++ b/hub/resourceeditors/storage.k8s.io/v1/storageclasses.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/storage.k8s.io/v1/volumeattachments.yaml
+++ b/hub/resourceeditors/storage.k8s.io/v1/volumeattachments.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/storage.k8s.io/v1beta1/csistoragecapacities.yaml
+++ b/hub/resourceeditors/storage.k8s.io/v1beta1/csistoragecapacities.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/supervisor.appscode.com/v1alpha1/approvalpolicies.yaml
+++ b/hub/resourceeditors/supervisor.appscode.com/v1alpha1/approvalpolicies.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/supervisor.appscode.com/v1alpha1/clustermaintenancewindows.yaml
+++ b/hub/resourceeditors/supervisor.appscode.com/v1alpha1/clustermaintenancewindows.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/supervisor.appscode.com/v1alpha1/maintenancewindows.yaml
+++ b/hub/resourceeditors/supervisor.appscode.com/v1alpha1/maintenancewindows.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/supervisor.appscode.com/v1alpha1/recommendations.yaml
+++ b/hub/resourceeditors/supervisor.appscode.com/v1alpha1/recommendations.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ui.k8s.appscode.com/v1alpha1/resourcedashboards.yaml
+++ b/hub/resourceeditors/ui.k8s.appscode.com/v1alpha1/resourcedashboards.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ui.k8s.appscode.com/v1alpha1/resourceeditors.yaml
+++ b/hub/resourceeditors/ui.k8s.appscode.com/v1alpha1/resourceeditors.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/elasticsearchinsights.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/elasticsearchinsights.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/elasticsearchnodesstats.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/elasticsearchnodesstats.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/elasticsearchschemaoverviews.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/elasticsearchschemaoverviews.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/mariadbinsights.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/mariadbinsights.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/mariadbqueries.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/mariadbqueries.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/mariadbschemaoverviews.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/mariadbschemaoverviews.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/mongodbinsights.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/mongodbinsights.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/mongodbqueries.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/mongodbqueries.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/mongodbschemaoverviews.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/mongodbschemaoverviews.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/mysqlinsights.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/mysqlinsights.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/mysqlqueries.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/mysqlqueries.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/mysqlschemaoverviews.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/mysqlschemaoverviews.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncerinsights.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncerinsights.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncerpooloverviews.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncerpooloverviews.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncerpools.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncerpools.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncerserveroverviews.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncerserveroverviews.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncersettings.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncersettings.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/postgresinsights.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/postgresinsights.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/postgresqueries.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/postgresqueries.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/postgresschemaoverviews.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/postgresschemaoverviews.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/postgressettings.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/postgressettings.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/proxysqlinsights.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/proxysqlinsights.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/proxysqlqueries.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/proxysqlqueries.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/proxysqlsettings.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/proxysqlsettings.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/redisinsights.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/redisinsights.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/redisqueries.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/redisqueries.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/redisschemaoverviews.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/redisschemaoverviews.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/ui.stash.appscode.com/v1alpha1/backupoverviews.yaml
+++ b/hub/resourceeditors/ui.stash.appscode.com/v1alpha1/backupoverviews.yaml
@@ -22,4 +22,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/voyager.appscode.com/v1/ingresses.yaml
+++ b/hub/resourceeditors/voyager.appscode.com/v1/ingresses.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15

--- a/hub/resourceeditors/voyager.appscode.com/v1beta1/ingresses.yaml
+++ b/hub/resourceeditors/voyager.appscode.com/v1beta1/ingresses.yaml
@@ -27,4 +27,4 @@ spec:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
         name: bytebuilders-ui
-      version: v0.4.14
+      version: v0.4.15


### PR DESCRIPTION
ProductLine: ByteBuilders
Release: v2023.05.12
Release-tracker: https://github.com/bytebuilders/CHANGELOG/pull/39
Signed-off-by: 1gtm <1gtm@appscode.com>