### PR TITLE
Use HermeticTxtFuncMap for table convertor templates

### DIFF
--- a/pkg/tableconvertor/templates.go
+++ b/pkg/tableconvertor/templates.go
@@ -42,7 +42,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/duration"
 )
 
-var templateFns = sprig.TxtFuncMap()
+var templateFns = sprig.HermeticTxtFuncMap()
 
 func init() {
 	templateFns["k8s_api_group"] = apiGroup


### PR DESCRIPTION
## Summary
- `pkg/tableconvertor/templates.go` registered sprig's full `TxtFuncMap()`, which exposes `env`, `expandenv`, and `getHostByName` to every user-controlled template field (ResourceTableDefinition, ResourceDashboard, link/tooltip/icon templates, CRD `additionalPrinterColumns`). Combined with the hub hot-reload trick documented in `hub/README.md`, a YAML author can read process env (license keys, kubeconfig tokens) or trigger SSRF/DNS exfil from the api-server process.
- Switching to `sprig.HermeticTxtFuncMap()` keeps every pure helper sprig provides while dropping the non-deterministic / non-hermetic ones.

## Test plan
- [ ] `make build` / `make unit-tests`
- [ ] Render a ResourceTableDefinition that uses sprig string/list/dict helpers — should be unaffected.
- [ ] Confirm no hub YAML relies on `env`, `expandenv`, `getHostByName`, `now`, `date*`, `rand*`, or `uuidv4` (a repo-wide grep at PR time showed only `.env` field accessors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)