### PR TITLE
Fix Registry.Resources/Kinds returning slices padded with empty entries

### DIFF
--- a/hub/registry.go
+++ b/hub/registry.go
@@ -481,7 +481,7 @@ func (r *Registry) Resources() []schema.GroupVersionResource {
 	r.m.RLock()
 	defer r.m.RUnlock()
 
-	out := make([]schema.GroupVersionResource, len(r.preferred))
+	out := make([]schema.GroupVersionResource, 0, len(r.preferred))
 	for _, gvr := range r.preferred {
 		out = append(out, gvr)
 	}
@@ -492,7 +492,7 @@ func (r *Registry) Kinds() []schema.GroupVersionKind {
 	r.m.RLock()
 	defer r.m.RUnlock()
 
-	out := make([]schema.GroupVersionKind, len(r.preferred))
+	out := make([]schema.GroupVersionKind, 0, len(r.preferred))
 	for _, gvr := range r.preferred {
 		out = append(out, r.regGVR[gvr].GroupVersionKind())
 	}


### PR DESCRIPTION
## Summary
- `Registry.Resources()` and `Registry.Kinds()` in `hub/registry.go` did `make([]T, len(r.preferred))` and then `append`, which pre-fills the slice with zero values and then appends past them. Callers received a slice that was ~2× the expected length, with the first half empty.
- Every consumer iterates phantom entries; `Kinds()` additionally indexes `r.regGVR[zeroGVR]` which is an empty `*ResourceDescriptor` and produces a zero `GroupVersionKind` per phantom.
- Switched both to `make([]T, 0, len(r.preferred))` so `append` starts at index 0.

## Test plan
- [ ] `make unit-tests`
- [ ] Verify `len(reg.Resources()) == len(reg.Kinds()) == <expected resource count>` against a known cluster
- [ ] Confirm `Visit()` (which routes through these) no longer emits zero GVRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)