### PR TITLE
check-edge-label: report missing target instead of panicking

### DIFF
--- a/cmd/check-edge-label/main.go
+++ b/cmd/check-edge-label/main.go
@@ -31,14 +31,21 @@ func main() {
 	reg := hub.NewRegistryOfKnownResources()
 	reg.Visit(func(key string, rdSrc *v1alpha1.ResourceDescriptor) {
 		for _, c := range rdSrc.Spec.Connections {
-			rdTarget, _ := reg.LoadByGVK(c.Target.GroupVersionKind())
-
 			offshoot := slices.Contains(c.Labels, kmapi.EdgeLabelOffshoot)
-			if offshoot {
-				if rdSrc.Spec.Resource.Scope != rdTarget.Spec.Resource.Scope {
-					fmt.Printf("%+v has an offshoot label edge with %+v, but their scope does not match\n", rdSrc.Spec.Resource.GroupVersionKind(), rdTarget.Spec.Resource.GroupVersionKind())
-					err++
-				}
+			if !offshoot {
+				continue
+			}
+
+			rdTarget, loadErr := reg.LoadByGVK(c.Target.GroupVersionKind())
+			if loadErr != nil || rdTarget == nil {
+				fmt.Printf("%+v has an offshoot label edge with %+v, but target is not registered\n", rdSrc.Spec.Resource.GroupVersionKind(), c.Target.GroupVersionKind())
+				err++
+				continue
+			}
+
+			if rdSrc.Spec.Resource.Scope != rdTarget.Spec.Resource.Scope {
+				fmt.Printf("%+v has an offshoot label edge with %+v, but their scope does not match\n", rdSrc.Spec.Resource.GroupVersionKind(), rdTarget.Spec.Resource.GroupVersionKind())
+				err++
 			}
 		}
 	})


### PR DESCRIPTION
## Summary
- `cmd/check-edge-label/main.go` discarded the `LoadByGVK` error and then dereferenced `rdTarget.Spec.Resource.Scope`. The first offshoot edge pointing to an unregistered target panicked the whole check, masking any subsequent violations.
- Now: skip the lookup when the edge has no offshoot label, report a clear "target is not registered" violation when `LoadByGVK` returns nil/err, and keep scanning.

## Test plan
- [ ] `go run ./cmd/check-edge-label` exits 0 against a clean tree (no offshoots with mismatched scope or missing targets)
- [ ] Temporarily point an offshoot connection at a bogus GVK and verify the tool now lists it instead of panicking

🤖 Generated with [Claude Code](https://claude.com/claude-code)