### PR TITLE
ToYAML: deep-copy validation schema before mutating

### DIFF
--- a/apis/meta/v1alpha1/resourcedescriptor_helpers.go
+++ b/apis/meta/v1alpha1/resourcedescriptor_helpers.go
@@ -46,6 +46,10 @@ func (rd ResourceDescriptor) ToYAML() ([]byte, error) {
 		if rd.Spec.Resource.Scope == kmapi.ClusterScoped {
 			delete(mc.Properties, "namespace")
 		}
+		// Deep-copy before mutating: Spec.Validation is a pointer that may be
+		// shared with the embedded registry; rewriting Properties in place
+		// corrupts the schema for every subsequent reader.
+		rd.Spec.Validation = rd.Spec.Validation.DeepCopy()
 		rd.Spec.Validation.OpenAPIV3Schema.Properties["metadata"] = mc
 		delete(rd.Spec.Validation.OpenAPIV3Schema.Properties, "status")
 	}


### PR DESCRIPTION
## Summary
- `ResourceDescriptor.ToYAML` in `apis/meta/v1alpha1/resourcedescriptor_helpers.go` has a value receiver, but `Spec.Validation` is `*crdv1.CustomResourceValidation` — a pointer shared with the embedded registry (`hub/resourcedescriptors/...`).
- Writing `Properties["metadata"]` and `delete(..., "status")` in place corrupted the in-memory schema for every subsequent reader of the same RD. `cmd/gen-docs` exhibits the same defect transitively because it calls this method.
- Fix: deep-copy `Spec.Validation` before rewriting.

## Test plan
- [ ] Call `ToYAML` twice on the same `ResourceDescriptor` and verify both outputs contain a `status` property in between (i.e. the original schema is not mutated).
- [ ] `make unit-tests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)