### PR TITLE
identity: drop IsGlobalUnicast from skipIP so routable cert IPs are kept

### DIFF
--- a/pkg/identity/siteinfo.go
+++ b/pkg/identity/siteinfo.go
@@ -221,7 +221,6 @@ func isControlPlaneNode(node *core.Node) bool {
 func skipIP(ip net.IP) bool {
 	return ip.IsLoopback() ||
 		ip.IsMulticast() ||
-		ip.IsGlobalUnicast() ||
 		ip.IsInterfaceLocalMulticast() ||
 		ip.IsLinkLocalMulticast() ||
 		ip.IsLinkLocalUnicast()


### PR DESCRIPTION
## Summary
- `pkg/identity/siteinfo.go` populates `ControlPlane.IPAddresses` with `if !skipIP(ip) { ips.Insert(...) }`. The `skipIP` helper included `ip.IsGlobalUnicast()` in the OR'd skip list — so every routable public unicast address (i.e. the actual control-plane endpoints from the api-server certificate) was filtered out.
- Net effect: `ControlPlane.IPAddresses` was almost always empty in practice.
- Drop `IsGlobalUnicast` from the skip list. Loopback, multicast, and link-local addresses are still skipped, which is what was actually intended.

## Test plan
- [ ] Capture an api-server cert with at least one public IP SAN, run identity collection, confirm the IP appears in `Kubernetes.ControlPlane.IPAddresses`.
- [ ] Confirm `127.0.0.1` / `::1` / `169.254.x.x` / multicast addresses are still excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)