### PR TITLE
tableconvertor: guard against empty Dashboards in init

### DIFF
--- a/pkg/tableconvertor/tableconvertor.go
+++ b/pkg/tableconvertor/tableconvertor.go
@@ -155,6 +155,9 @@ func (c *convertor) init(columns []rsapi.ResourceColumnDefinition, fnDashboard D
 			if obj, url, err := fnDashboard(c.Dashboard.Name); err != nil {
 				c.Dashboard.Status = rsapi.RenderError
 				c.Dashboard.Message = err.Error()
+			} else if len(obj.Spec.Dashboards) == 0 {
+				c.Dashboard.Status = rsapi.RenderError
+				c.Dashboard.Message = fmt.Sprintf("ResourceDashboard %s has no dashboards", c.Dashboard.Name)
 			} else {
 				c.Dashboard.Dashboard = func(in *uiapi.Dashboard) *shared.Dashboard {
 					out := shared.Dashboard{


### PR DESCRIPTION
## Summary
- `pkg/tableconvertor/tableconvertor.go` indexed `obj.Spec.Dashboards[0]` after `fnDashboard(...)` without a length check. A `ResourceDashboard` with no embedded dashboards (legacy YAML, partial hot-reload) panicked every `ConvertToTable` on that column.
- Now: when `Dashboards` is empty, surface the misconfiguration as `RenderError` with a clear message, the same way other lookup failures are reported.

## Test plan
- [ ] `make unit-tests`
- [ ] Render a column whose `Dashboard.Name` resolves to a `ResourceDashboard` with empty `Spec.Dashboards` and confirm the cell reports an error instead of panicking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)