### PR TITLE
tableconvertor: parse memory quantities via resource.ParseQuantity

### DIFF
--- a/pkg/tableconvertor/util.go
+++ b/pkg/tableconvertor/util.go
@@ -364,43 +364,14 @@ func describeVolume(volume core.Volume) string {
 	return fmt.Sprintf("{\"name\": %q,\"Type\":\"<unknown>\"}", volume.Name)
 }
 
-// convertSizeToBytes converts any dataSize(Mi,Gi,Ti,Ki) to Bytes
+// convertSizeToBytes converts a Kubernetes quantity string (e.g. "1Gi",
+// "500M", "8589934592") to a number of bytes.
 func convertSizeToBytes(dataSize string) (float64, error) {
-	var size float64
-
-	switch {
-	case strings.HasSuffix(dataSize, "Ti"):
-		_, err := fmt.Sscanf(dataSize, "%fTi", &size)
-		if err != nil {
-			return 0, err
-		}
-		return size * (1 << 40), nil
-	case strings.HasSuffix(dataSize, "Gi"):
-		_, err := fmt.Sscanf(dataSize, "%fGi", &size)
-		if err != nil {
-			return 0, err
-		}
-		return size * (1 << 30), nil
-	case strings.HasSuffix(dataSize, "Mi"):
-		_, err := fmt.Sscanf(dataSize, "%fMi", &size)
-		if err != nil {
-			return 0, err
-		}
-		return size * (1 << 20), nil
-	case strings.HasSuffix(dataSize, "Ki"):
-		_, err := fmt.Sscanf(dataSize, "%fKi", &size)
-		if err != nil {
-			return 0, err
-		}
-		return size * (1 << 10), nil
-	default:
-		_, err := fmt.Sscanf(dataSize, "%fB", &size)
-		if err != nil {
-			return 0, err
-		}
-		return size, nil
-
+	q, err := resource.ParseQuantity(dataSize)
+	if err != nil {
+		return 0, err
 	}
+	return q.AsApproximateFloat64(), nil
 }
 
 // ConvertToHumanReadableDateType returns the elapsed time since timestamp in


### PR DESCRIPTION
## Summary
- `convertSizeToBytes` in `pkg/tableconvertor/util.go` used `fmt.Sscanf` with a strict format string and required either a binary suffix (`Ki`/`Mi`/`Gi`/`Ti`) or a trailing `B`. Legit Kubernetes quantity strings — plain integer bytes (`8589934592`), SI units (`1G`, `1k`), decimal-with-suffix (`1.5Gi`), exponentials — all returned an error.
- The error propagates from `formatResourceMemoryFn` (`k8s_fmt_resource_memory`) and fails the entire row render.
- Replace with `resource.ParseQuantity(...).AsApproximateFloat64()`. `k8s.io/apimachinery/pkg/api/resource` is already imported.

## Test plan
- [ ] `make unit-tests`
- [ ] Render a column that uses `k8s_fmt_resource_memory` against pods with: a raw-byte allocatable value, an `Mi`-suffixed limit, a decimal `1.5Gi` request, and an SI `1G` value — confirm all render without error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)