### PR TITLE
ui-updater: fail loudly when digest resolution fails

### DIFF
--- a/cmd/ui-updater/main.go
+++ b/cmd/ui-updater/main.go
@@ -193,9 +193,14 @@ func getDigestOrVersion(repo, bin, ver string) string {
 	if repo != "appscode-charts-oci" {
 		return ver
 	}
-	digest, err := crane.Digest(fmt.Sprintf("ghcr.io/appscode-charts/%s:%s", bin, ver), crane.WithAuthFromKeychain(authn.DefaultKeychain))
-	if err == nil {
-		return digest
+	ref := fmt.Sprintf("ghcr.io/appscode-charts/%s:%s", bin, ver)
+	digest, err := crane.Digest(ref, crane.WithAuthFromKeychain(authn.DefaultKeychain))
+	if err != nil {
+		// Don't silently downgrade from a pinned digest to a mutable tag —
+		// surface the failure so the operator can decide whether to retry
+		// or accept the un-pinned version.
+		fmt.Fprintf(os.Stderr, "ERROR: failed to resolve digest for %s: %v\n", ref, err)
+		os.Exit(1)
 	}
-	return ver
+	return digest
 }


### PR DESCRIPTION
## Summary
- `getDigestOrVersion` in `cmd/ui-updater/main.go` silently returned the plain version tag whenever `crane.Digest` failed. A transient network/auth failure during a refresh run quietly downgraded the committed YAML from a pinned digest to a mutable tag — invisible in the diff.
- Now: print the failed reference + error to stderr and exit non-zero so the operator notices and can retry rather than committing an un-pinned version.

## Test plan
- [ ] Run `go run ./cmd/ui-updater --use-digest` with valid auth → existing behaviour, all charts resolved to digests.
- [ ] Temporarily point at an unreachable ref → tool exits 1 with a clear stderr message instead of writing tag versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)