### PR TITLE
import-crds: handle read/unmarshal errors explicitly in WriteDescriptor

### DIFF
--- a/cmd/import-crds/main.go
+++ b/cmd/import-crds/main.go
@@ -328,7 +328,14 @@ func WriteDescriptor(crd *crdv1.CustomResourceDefinition, dir string) error {
 		filename := filepath.Join(baseDir, plural+".yaml")
 
 		var rd rsapi.ResourceDescriptor
-		if existing, err := os.ReadFile(filename); os.IsNotExist(err) {
+		existing, readErr := os.ReadFile(filename)
+		switch {
+		case readErr == nil:
+			if err := yaml.Unmarshal(existing, &rd); err != nil {
+				return fmt.Errorf("failed to unmarshal %s: %w", filename, err)
+			}
+			rd.Spec.Validation = v.Schema
+		case os.IsNotExist(readErr):
 			rd = rsapi.ResourceDescriptor{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: rsapi.SchemeGroupVersion.String(),
@@ -354,11 +361,8 @@ func WriteDescriptor(crd *crdv1.CustomResourceDefinition, dir string) error {
 					Validation: v.Schema,
 				},
 			}
-		} else {
-			err = yaml.Unmarshal(existing, &rd)
-			if err == nil {
-				rd.Spec.Validation = v.Schema
-			}
+		default:
+			return fmt.Errorf("failed to read %s: %w", filename, readErr)
 		}
 
 		if rd.Spec.Validation != nil &&


### PR DESCRIPTION
## Summary
- `WriteDescriptor` in `cmd/import-crds/main.go` only special-cased `os.IsNotExist(err)` from `os.ReadFile`. Any other read error (permission denied, IO failure, race) fell through to the else-branch with `existing == nil`, then `yaml.Unmarshal(nil, &rd)` succeeded with an empty rd, and the unmarshal error was swallowed by `if err == nil { ... }`.
- Net effect: ResourceDescriptor file on disk gets overwritten with a partially populated RD whenever the original couldn't be read or was corrupted.
- Replace with an explicit `switch` on the read error: `nil` → unmarshal (fail loud on bad YAML), `IsNotExist` → build fresh, anything else → return the error.

## Test plan
- [ ] `go run ./cmd/import-crds ...` against the normal CRD set produces a no-op (existing files round-trip cleanly).
- [ ] Temporarily chmod 000 an existing RD file → tool returns a clear error instead of overwriting with a stub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)