### PR TITLE
resource-fmt: track failures and exit non-zero

### DIFF
--- a/cmd/resource-fmt/main.go
+++ b/cmd/resource-fmt/main.go
@@ -35,15 +35,16 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-func handlePanic(filename string) {
+func handlePanic(filename string, retErr *error) {
 	a := recover()
 	if a != nil {
 		fmt.Println("RECOVER", filename, a)
+		*retErr = fmt.Errorf("panic while processing %s: %v", filename, a)
 	}
 }
 
-func check(typ reflect.Type, filename string, fix bool) (string, error) {
-	defer handlePanic(filename)
+func check(typ reflect.Type, filename string, fix bool) (out string, err error) {
+	defer handlePanic(filename, &err)
 
 	data, err := os.ReadFile(filename)
 	if err != nil {
@@ -135,9 +136,12 @@ func checkType(t any, plural string, fix bool) error {
 	})
 }
 
+var failures int
+
 func MustCheckType(t any, plural string, fix bool) {
 	if err := checkType(t, plural, fix); err != nil {
 		klog.ErrorS(err, "failed to check "+plural)
+		failures++
 	}
 }
 
@@ -153,4 +157,8 @@ func main() {
 	MustCheckType(metaapi.ResourceOutline{}, "resourceoutlines", *fix)
 	MustCheckType(metaapi.ResourceTableDefinition{}, "resourcetabledefinitions", *fix)
 	MustCheckType(uiapi.ResourceDashboard{}, "resourcedashboards", *fix)
+
+	if failures > 0 {
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
## Summary
- `MustCheckType` logged each failure via `klog.ErrorS` and returned, so `main()` always exited 0 — CI claims the tool enforced an invariant but it never did. A malformed RD would merge silently with a loud-looking error line in the log.
- `handlePanic` recovered without setting the named return values, so the post-recovery return was `("", nil)` — a panic inside `check()` reported "clean" to the caller.
- Track failures in a package-level counter, `os.Exit(1)` when non-zero. Convert recovered panics into a real error via a named return.
- Default `fix=true` is preserved because `make fmt` invokes the tool with no flags and depends on the fixing behaviour; `make verify-gen` is what fails CI when the resulting tree is dirty.

## Test plan
- [ ] Normal run: `go run ./cmd/resource-fmt` exits 0 on a clean tree.
- [ ] Introduce a YAML with a typed-field error in `hub/resourcedescriptors/…` and confirm the tool exits 1 with a clear log line.
- [ ] Trigger a panic in `check()` (e.g. by corrupting a known-good RD) and confirm `RECOVER` is printed AND the process exits 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)