### PR TITLE
tableconvertor: cache parsed templates

### DIFF
--- a/pkg/tableconvertor/tableconvertor.go
+++ b/pkg/tableconvertor/tableconvertor.go
@@ -51,6 +51,23 @@ var pool = sync.Pool{
 	},
 }
 
+// templateCache caches parsed templates keyed by template source string.
+// text/template.Template.Execute is safe for concurrent use, and column
+// templates are immutable for the life of the process.
+var templateCache sync.Map // map[string]*template.Template
+
+func parseTemplate(src string) (*template.Template, error) {
+	if cached, ok := templateCache.Load(src); ok {
+		return cached.(*template.Template), nil
+	}
+	tpl, err := template.New("").Funcs(templateFns).Option("missingkey=default").Parse(src)
+	if err != nil {
+		return nil, err
+	}
+	actual, _ := templateCache.LoadOrStore(src, tpl)
+	return actual.(*template.Template), nil
+}
+
 type TableConvertor interface {
 	ConvertToTable(ctx context.Context, object runtime.Object) (*rsapi.Table, error)
 }
@@ -393,7 +410,7 @@ func renderTemplate(data any, col columnOptions, buf *bytes.Buffer) (any, error)
 		return nil, nil
 	}
 
-	tpl, err := template.New("").Funcs(templateFns).Parse(col.Template)
+	tpl, err := parseTemplate(col.Template)
 	if err != nil {
 		klog.ErrorS(err, "failed to parse column template", "name", col.Name, "template", col.Template)
 		return nil, errors.Wrapf(err, "falied to parse column %+v", col)
@@ -401,7 +418,6 @@ func renderTemplate(data any, col columnOptions, buf *bytes.Buffer) (any, error)
 	// Do nothing and continue execution.
 	// If printed, the result of the index operation is the string "<no value>".
 	// We mitigate that later.
-	tpl.Option("missingkey=default")
 	buf.Reset()
 	err = tpl.Execute(buf, data)
 	if err != nil {


### PR DESCRIPTION
## Summary
- `renderTemplate` in `pkg/tableconvertor/tableconvertor.go` called `template.New("").Funcs(templateFns).Parse(col.Template)` on every invocation. For an N-row list with up to six template-bearing fields per column (PathTemplate, Sort, Link, Tooltip, Icon, Color), parse cost scaled as O(N × M) per `ConvertToTable`.
- Cache parsed templates in a process-wide `sync.Map` keyed by the template source string. `text/template.Template.Execute` is safe for concurrent use; column templates are immutable once authored, so the singleton-per-source scope is correct.
- `missingkey=default` is now applied at parse time alongside the FuncMap (used to be set on every call after Parse — functionally equivalent).

## Test plan
- [ ] `make unit-tests`
- [ ] Spot check a list endpoint that exercises sprig + project funcs in column templates — output unchanged
- [ ] Optionally benchmark `ConvertToTable` on a 1000-row list to confirm the reduction in allocations

🤖 Generated with [Claude Code](https://claude.com/claude-code)