### PR TITLE
hub: stop sharing the embedded descriptor map across registries

### DIFF
--- a/hub/kv.go
+++ b/hub/kv.go
@@ -17,6 +17,7 @@ limitations under the License.
 package hub
 
 import (
+	"maps"
 	"sync"
 
 	"kmodules.xyz/resource-metadata/apis/meta/v1alpha1"
@@ -38,6 +39,18 @@ type KVMap struct {
 var _ KV = &KVMap{}
 
 func NewKVMap(cache map[string]*v1alpha1.ResourceDescriptor) KV {
+	return &KVMap{cache: cache}
+}
+
+// NewKVMapFromKnown returns a KVMap seeded with a shallow copy of the
+// embedded known-descriptors map. Use this when constructing per-cluster
+// registries so that each registry mutates its own map: KnownDescriptors()
+// returns the package-global map, and sharing it across registries leads to
+// concurrent-map-writes when several clusters discover CRDs simultaneously.
+func NewKVMapFromKnown() KV {
+	known := resourcedescriptors.KnownDescriptors()
+	cache := make(map[string]*v1alpha1.ResourceDescriptor, len(known))
+	maps.Copy(cache, known)
 	return &KVMap{cache: cache}
 }
 
@@ -72,9 +85,7 @@ var _ KV = &KVLocal{}
 
 func NewKVLocal() KV {
 	return &KVLocal{
-		known: &KVMap{
-			cache: resourcedescriptors.KnownDescriptors(),
-		},
+		known: NewKVMapFromKnown(),
 		cache: map[string]*v1alpha1.ResourceDescriptor{},
 	}
 }

--- a/hub/registry.go
+++ b/hub/registry.go
@@ -94,9 +94,7 @@ func NewRegistry(uid string, cache KV) *Registry {
 }
 
 func NewRegistryOfKnownResources() *Registry {
-	return NewRegistry(KnownUID, &KVMap{
-		cache: resourcedescriptors.KnownDescriptors(),
-	})
+	return NewRegistry(KnownUID, NewKVMapFromKnown())
 }
 
 func (r *Registry) DiscoverResources(cfg *rest.Config) error {


### PR DESCRIPTION
## Summary
- `NewRegistryOfKnownResources` and `NewKVLocal` both wrapped `resourcedescriptors.KnownDescriptors()` — the *package-global* map — directly into a `KVMap`. Each `Registry` held its own `RWMutex`, but `KVMap.Set` wrote into the same underlying Go map under different locks.
- With `PoolSize = 1024` clusters, a CRD discovery from cluster A and one from cluster B can hit `Set` simultaneously and trigger Go's runtime `fatal error: concurrent map writes` — a process crash, not silent corruption.
- Introduce `NewKVMapFromKnown()` which copies the map before wrapping, and use it from both in-tree construction sites. `KnownDescriptors()` is unchanged so out-of-tree consumers keep working; any pool factory that constructs a `KVMap` directly from `KnownDescriptors()` should migrate to this helper.

## Test plan
- [ ] `make unit-tests`
- [ ] `go test -race ./hub/...` — exercise the registry concurrently via a small in-package test that spins multiple goroutines calling `Set` on different registries built from `NewRegistryOfKnownResources`. (Optional follow-up if not yet present.)
- [ ] Smoke-test kube-ui-server with two clusters discovering distinct CRDs simultaneously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)