### PR TITLE
hub: preserve manually-registered GVRs across discovery refresh

### DIFF
--- a/hub/registry.go
+++ b/hub/registry.go
@@ -113,6 +113,15 @@ func (r *Registry) discoverResources() error {
 		return err
 	}
 
+	// Preserve manually-registered GroupResources that server discovery did
+	// not see (e.g. a CRD just applied but not yet in the discovery cache).
+	// Discovery wins for GroupResources it does know about, since the
+	// api-server is authoritative on its own preferred version.
+	for gr, gvr := range r.preferred {
+		if _, ok := preferred[gr]; !ok {
+			preferred[gr] = gvr
+		}
+	}
 	r.preferred = preferred
 	r.lastRefreshed = time.Now()
 	for filename, rd := range reg {


### PR DESCRIPTION
## Summary
- `discoverResources` in `hub/registry.go` rebuilt `r.preferred` from server discovery alone (`r.preferred = preferred`). A GroupResource added via `RegisterGVR` — typically a freshly-applied CRD that isn't yet in the api-server's discovery cache — was wiped on the next `Refresh()`.
- The entry survived in `regGVK` / `regGVR` (those are merged from `reg`), so the registry's view became inconsistent: `Preferred()` reported "no such GR" while `GVR()` / `Get()` still returned the descriptor.
- Merge instead: take discovery as the base, then preserve any existing `r.preferred` entry whose `GroupResource` discovery didn't see. Discovery still wins for shared keys because the api-server is authoritative.

## Test plan
- [ ] Apply a new CRD, immediately call `RegisterGVR(...)`, then trigger `Refresh()` before the api-server's discovery cache catches up — confirm `Preferred()` still reports the GVR.
- [ ] When the same CRD eventually appears in discovery with a different preferred version, confirm the discovered version replaces the manually-registered one.
- [ ] `make unit-tests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)