### PR TITLE
hub: log LRU registry evictions

### DIFF
--- a/hub/pool.go
+++ b/hub/pool.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	lru "github.com/hashicorp/golang-lru"
+	"k8s.io/klog/v2"
 )
 
 type Pool struct {
@@ -31,7 +32,15 @@ type Pool struct {
 const PoolSize = 1024 // This number should match the max number of concurrent clusters handled
 
 func NewPool(kvFactory func() KV) (*Pool, error) {
-	cache, err := lru.New(PoolSize)
+	// Log evictions so it's visible when the pool is undersized for the
+	// workload. With each registry now owning its own KV map (see
+	// NewKVMapFromKnown), an evicted registry just becomes garbage as
+	// in-flight goroutines release it — but any work it had buffered
+	// (e.g. recent RegisterGVR calls) is gone, so frequent evictions are
+	// worth surfacing.
+	cache, err := lru.NewWithEvict(PoolSize, func(key, _ interface{}) {
+		klog.V(2).InfoS("evicted cluster registry from pool", "uid", key)
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- The cluster `Registry` pool is a fixed-size LRU (`PoolSize=1024`). Evictions currently happen silently; an operator has no way to know the pool is undersized for the workload until they notice symptoms (re-discovery storms, lost `RegisterGVR` state on subsequent access).
- This PR pairs with #632 ("stop sharing the embedded descriptor map"). With each registry owning its own KV map, an evicted registry no longer corrupts shared state — but any work buffered locally (recent `RegisterGVR` additions, the current cached `preferred` map, `lastRefreshed`) is gone, and that's worth surfacing.
- Switch to `lru.NewWithEvict` and log at `V(2)` so the signal is quiet by default, but greppable when investigating "why does this cluster's registry keep cold-starting?"

## Note on the more invasive options
- True ref-counted handoff (so in-flight goroutines on an evicted registry continue to mutate the canonical instance) is a deeper change than what this PR attempts. Logging is the minimum that makes the issue diagnosable; #632 makes it benign.

## Test plan
- [ ] `make unit-tests`
- [ ] Smoke-test with `PoolSize` artificially lowered (e.g. 4) and 10+ unique cluster UIDs; verify `evicted cluster registry from pool` lines appear at `-v=2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)