### PR TITLE
hub: keep previous state when reload fails

### DIFF
--- a/hub/clusterprofiles/lib.go
+++ b/hub/clusterprofiles/lib.go
@@ -31,6 +31,7 @@ import (
 	ioutilx "gomodules.xyz/x/ioutil"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 )
@@ -46,7 +47,7 @@ var (
 		filepath.Join("/tmp", "hub", "clusterprofiles"),
 		fs,
 		func(fsys iofs.FS) {
-			cpMap = map[string]*v1alpha1.ClusterProfile{}
+			next := map[string]*v1alpha1.ClusterProfile{}
 
 			if err := iofs.WalkDir(fsys, ".", func(path string, d iofs.DirEntry, err error) error {
 				if d.IsDir() || err != nil {
@@ -66,11 +67,16 @@ var (
 				if err != nil {
 					return errors.Wrap(err, path)
 				}
-				cpMap[obj.Name] = &obj
+				next[obj.Name] = &obj
 				return nil
 			}); err != nil {
-				panic(errors.Wrapf(err, "failed to load %s", reflect.TypeFor[v1alpha1.ClusterProfile]()))
+				if cpMap == nil {
+					panic(errors.Wrapf(err, "failed to load %s", reflect.TypeFor[v1alpha1.ClusterProfile]()))
+				}
+				klog.ErrorS(err, "failed to reload clusterprofiles; keeping previous state")
+				return
 			}
+			cpMap = next
 		},
 	)
 )

--- a/hub/menuoutlines/lib.go
+++ b/hub/menuoutlines/lib.go
@@ -32,6 +32,7 @@ import (
 	"golang.org/x/net/publicsuffix"
 	ioutilx "gomodules.xyz/x/ioutil"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/yaml"
 )
 
@@ -46,7 +47,7 @@ var (
 		filepath.Join("/tmp", "hub", "menuoutlines"),
 		fs,
 		func(fsys iofs.FS) {
-			moMap = map[string]*v1alpha1.MenuOutline{}
+			next := map[string]*v1alpha1.MenuOutline{}
 
 			if err := iofs.WalkDir(fsys, ".", func(path string, d iofs.DirEntry, err error) error {
 				if d.IsDir() || err != nil {
@@ -66,11 +67,16 @@ var (
 				if err != nil {
 					return errors.Wrap(err, path)
 				}
-				moMap[obj.Name] = &obj
+				next[obj.Name] = &obj
 				return nil
 			}); err != nil {
-				panic(errors.Wrapf(err, "failed to load %s", reflect.TypeFor[v1alpha1.MenuOutline]()))
+				if moMap == nil {
+					panic(errors.Wrapf(err, "failed to load %s", reflect.TypeFor[v1alpha1.MenuOutline]()))
+				}
+				klog.ErrorS(err, "failed to reload menuoutlines; keeping previous state")
+				return
 			}
+			moMap = next
 		},
 	)
 )

--- a/hub/resourceblockdefinitions/lib.go
+++ b/hub/resourceblockdefinitions/lib.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pkg/errors"
 	ioutilx "gomodules.xyz/x/ioutil"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/yaml"
 )
 
@@ -43,7 +44,7 @@ var (
 		filepath.Join("/tmp", "hub", "resourceblockdefinitions"),
 		fs,
 		func(fsys iofs.FS) {
-			rbMap = map[string]*v1alpha1.ResourceBlockDefinition{}
+			next := map[string]*v1alpha1.ResourceBlockDefinition{}
 
 			if err := iofs.WalkDir(fsys, ".", func(path string, d iofs.DirEntry, err error) error {
 				if d.IsDir() || err != nil {
@@ -63,11 +64,16 @@ var (
 				if err != nil {
 					return errors.Wrap(err, path)
 				}
-				rbMap[obj.Name] = &obj
+				next[obj.Name] = &obj
 				return nil
 			}); err != nil {
-				panic(errors.Wrapf(err, "failed to load %s", reflect.TypeFor[v1alpha1.ResourceBlockDefinition]()))
+				if rbMap == nil {
+					panic(errors.Wrapf(err, "failed to load %s", reflect.TypeFor[v1alpha1.ResourceBlockDefinition]()))
+				}
+				klog.ErrorS(err, "failed to reload resourceblockdefinitions; keeping previous state")
+				return
 			}
+			rbMap = next
 		},
 	)
 )

--- a/hub/resourcedashboards/lib.go
+++ b/hub/resourcedashboards/lib.go
@@ -34,6 +34,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 )
@@ -49,7 +50,7 @@ var (
 		filepath.Join("/tmp", "hub", "resourcedashboards"),
 		fs,
 		func(fsys iofs.FS) {
-			rdMap = map[string]*v1alpha1.ResourceDashboard{}
+			next := map[string]*v1alpha1.ResourceDashboard{}
 
 			if err := iofs.WalkDir(fsys, ".", func(path string, d iofs.DirEntry, err error) error {
 				if d.IsDir() || err != nil {
@@ -69,12 +70,17 @@ var (
 				if err != nil {
 					return errors.Wrap(err, path)
 				}
-				rdMap[obj.Name] = &obj
+				next[obj.Name] = &obj
 
 				return nil
 			}); err != nil {
-				panic(errors.Wrapf(err, "failed to load %s", reflect.TypeFor[v1alpha1.ResourceDashboard]()))
+				if rdMap == nil {
+					panic(errors.Wrapf(err, "failed to load %s", reflect.TypeFor[v1alpha1.ResourceDashboard]()))
+				}
+				klog.ErrorS(err, "failed to reload resourcedashboards; keeping previous state")
+				return
 			}
+			rdMap = next
 		},
 	)
 )

--- a/hub/resourcedescriptors/lib.go
+++ b/hub/resourcedescriptors/lib.go
@@ -32,6 +32,7 @@ import (
 	ioutilx "gomodules.xyz/x/ioutil"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/yaml"
 )
 
@@ -47,8 +48,8 @@ var (
 		filepath.Join("/tmp", "hub", "resourcedescriptors"),
 		fs,
 		func(fsys iofs.FS) {
-			knownDescriptors = map[string]*v1alpha1.ResourceDescriptor{}
-			latestGVRs = map[schema.GroupKind]schema.GroupVersionResource{}
+			nextKnown := map[string]*v1alpha1.ResourceDescriptor{}
+			nextLatest := map[schema.GroupKind]schema.GroupVersionResource{}
 
 			e2 := iofs.WalkDir(fsys, ".", func(path string, d iofs.DirEntry, err error) error {
 				if d.IsDir() || err != nil {
@@ -68,20 +69,27 @@ var (
 				if err != nil {
 					return errors.Wrap(err, path)
 				}
-				knownDescriptors[rd.Name] = &rd
+				nextKnown[rd.Name] = &rd
 
 				gvr := rd.Spec.Resource.GroupVersionResource()
 				gk := rd.Spec.Resource.GroupKind()
-				if existing, ok := latestGVRs[gk]; !ok {
-					latestGVRs[gk] = gvr
+				if existing, ok := nextLatest[gk]; !ok {
+					nextLatest[gk] = gvr
 				} else if diff, _ := apiversion.Compare(existing.Version, gvr.Version); diff < 0 {
-					latestGVRs[gk] = gvr
+					nextLatest[gk] = gvr
 				}
 				return err
 			})
 			if e2 != nil {
-				panic(errors.Wrapf(e2, "failed to load %s", reflect.TypeFor[v1alpha1.ResourceDescriptor]()))
+				if knownDescriptors == nil {
+					// First load (init); embedded data must be valid.
+					panic(errors.Wrapf(e2, "failed to load %s", reflect.TypeFor[v1alpha1.ResourceDescriptor]()))
+				}
+				klog.ErrorS(e2, "failed to reload resourcedescriptors; keeping previous state")
+				return
 			}
+			knownDescriptors = nextKnown
+			latestGVRs = nextLatest
 		},
 	)
 )

--- a/hub/resourceeditors/lib.go
+++ b/hub/resourceeditors/lib.go
@@ -34,6 +34,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 )
@@ -49,7 +50,7 @@ var (
 		filepath.Join("/tmp", "hub", "resourceeditors"),
 		fs,
 		func(fsys iofs.FS) {
-			reMap = map[string]*v1alpha1.ResourceEditor{}
+			next := map[string]*v1alpha1.ResourceEditor{}
 
 			if err := iofs.WalkDir(fsys, ".", func(path string, d iofs.DirEntry, err error) error {
 				if d.IsDir() || err != nil {
@@ -69,12 +70,17 @@ var (
 				if err != nil {
 					return errors.Wrap(err, path)
 				}
-				reMap[obj.Name] = &obj
+				next[obj.Name] = &obj
 
 				return nil
 			}); err != nil {
-				panic(errors.Wrapf(err, "failed to load %s", reflect.TypeFor[v1alpha1.ResourceEditor]()))
+				if reMap == nil {
+					panic(errors.Wrapf(err, "failed to load %s", reflect.TypeFor[v1alpha1.ResourceEditor]()))
+				}
+				klog.ErrorS(err, "failed to reload resourceeditors; keeping previous state")
+				return
 			}
+			reMap = next
 		},
 	)
 )

--- a/hub/resourceoutlines/lib.go
+++ b/hub/resourceoutlines/lib.go
@@ -31,6 +31,7 @@ import (
 	ioutilx "gomodules.xyz/x/ioutil"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/yaml"
 )
 
@@ -47,9 +48,9 @@ var (
 		filepath.Join("/tmp", "hub", "resourceoutlines"),
 		fs,
 		func(fsys iofs.FS) {
-			rlMap = map[string]*v1alpha1.ResourceOutline{}
-			rlPerGK = map[schema.GroupVersionKind]*v1alpha1.ResourceOutline{}
-			rlPerGR = map[schema.GroupVersionResource]*v1alpha1.ResourceOutline{}
+			nextMap := map[string]*v1alpha1.ResourceOutline{}
+			nextPerGK := map[schema.GroupVersionKind]*v1alpha1.ResourceOutline{}
+			nextPerGR := map[schema.GroupVersionResource]*v1alpha1.ResourceOutline{}
 
 			if err := iofs.WalkDir(fsys, ".", func(path string, d iofs.DirEntry, err error) error {
 				if d.IsDir() || err != nil {
@@ -69,7 +70,7 @@ var (
 				if err != nil {
 					return errors.Wrap(err, path)
 				}
-				rlMap[obj.Name] = &obj
+				nextMap[obj.Name] = &obj
 
 				if obj.Spec.DefaultLayout {
 					gvr := obj.Spec.Resource.GroupVersionResource()
@@ -79,21 +80,28 @@ var (
 					}
 
 					gvk := obj.Spec.Resource.GroupVersionKind()
-					if rv, ok := rlPerGK[gvk]; !ok {
-						rlPerGK[gvk] = &obj
+					if rv, ok := nextPerGK[gvk]; !ok {
+						nextPerGK[gvk] = &obj
 					} else {
 						return fmt.Errorf("multiple %s found for %+v: %s and %s", reflect.TypeFor[v1alpha1.ResourceOutline](), gvk, rv.Name, obj.Name)
 					}
-					if rv, ok := rlPerGR[gvr]; !ok {
-						rlPerGR[gvr] = &obj
+					if rv, ok := nextPerGR[gvr]; !ok {
+						nextPerGR[gvr] = &obj
 					} else {
 						return fmt.Errorf("multiple %s found for %+v: %s and %s", reflect.TypeFor[v1alpha1.ResourceOutline](), gvk, rv.Name, obj.Name)
 					}
 				}
 				return nil
 			}); err != nil {
-				panic(errors.Wrapf(err, "failed to load %s", reflect.TypeFor[v1alpha1.ResourceOutline]()))
+				if rlMap == nil {
+					panic(errors.Wrapf(err, "failed to load %s", reflect.TypeFor[v1alpha1.ResourceOutline]()))
+				}
+				klog.ErrorS(err, "failed to reload resourceoutlines; keeping previous state")
+				return
 			}
+			rlMap = nextMap
+			rlPerGK = nextPerGK
+			rlPerGR = nextPerGR
 		},
 	)
 )

--- a/hub/resourcetabledefinitions/lib.go
+++ b/hub/resourcetabledefinitions/lib.go
@@ -31,6 +31,7 @@ import (
 	ioutilx "gomodules.xyz/x/ioutil"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/yaml"
 )
 
@@ -47,9 +48,9 @@ var (
 		filepath.Join("/tmp", "hub", "resourcetabledefinitions"),
 		fs,
 		func(fsys iofs.FS) {
-			rtdMap = map[string]*v1alpha1.ResourceTableDefinition{}
-			rtdPerGK = map[schema.GroupVersionKind]*v1alpha1.ResourceTableDefinition{}
-			rtdPerGR = map[schema.GroupVersionResource]*v1alpha1.ResourceTableDefinition{}
+			nextMap := map[string]*v1alpha1.ResourceTableDefinition{}
+			nextPerGK := map[schema.GroupVersionKind]*v1alpha1.ResourceTableDefinition{}
+			nextPerGR := map[schema.GroupVersionResource]*v1alpha1.ResourceTableDefinition{}
 
 			if err := iofs.WalkDir(fsys, ".", func(path string, d iofs.DirEntry, err error) error {
 				if d.IsDir() || err != nil {
@@ -69,26 +70,33 @@ var (
 				if err != nil {
 					return errors.Wrap(err, path)
 				}
-				rtdMap[obj.Name] = &obj
+				nextMap[obj.Name] = &obj
 
 				if obj.Spec.Resource != nil && obj.Spec.DefaultView {
 					gvk := obj.Spec.Resource.GroupVersionKind()
-					if rv, ok := rtdPerGK[gvk]; !ok {
-						rtdPerGK[gvk] = &obj
+					if rv, ok := nextPerGK[gvk]; !ok {
+						nextPerGK[gvk] = &obj
 					} else {
 						return fmt.Errorf("multiple %s found for %+v: %s and %s", reflect.TypeFor[v1alpha1.ResourceTableDefinition](), gvk, rv.Name, obj.Name)
 					}
 					gvr := obj.Spec.Resource.GroupVersionResource()
-					if rv, ok := rtdPerGR[gvr]; !ok {
-						rtdPerGR[gvr] = &obj
+					if rv, ok := nextPerGR[gvr]; !ok {
+						nextPerGR[gvr] = &obj
 					} else {
 						return fmt.Errorf("multiple %s found for %+v: %s and %s", reflect.TypeFor[v1alpha1.ResourceTableDefinition](), gvk, rv.Name, obj.Name)
 					}
 				}
 				return nil
 			}); err != nil {
-				panic(errors.Wrapf(err, "failed to load %s", reflect.TypeFor[v1alpha1.ResourceTableDefinition]()))
+				if rtdMap == nil {
+					panic(errors.Wrapf(err, "failed to load %s", reflect.TypeFor[v1alpha1.ResourceTableDefinition]()))
+				}
+				klog.ErrorS(err, "failed to reload resourcetabledefinitions; keeping previous state")
+				return
 			}
+			rtdMap = nextMap
+			rtdPerGK = nextPerGK
+			rtdPerGR = nextPerGR
 		},
 	)
 )


### PR DESCRIPTION
## Summary
- All eight hub YAML loaders (`hub/resourcedescriptors/lib.go`, `resourceeditors/`, `resourcedashboards/`, `resourceoutlines/`, `resourcetabledefinitions/`, `resourceblockdefinitions/`, `menuoutlines/`, `clusterprofiles/`) wiped the package-global map at the start of every reload and `panic`ed on any walk/unmarshal error.
- `ReloadIfTriggered` is invoked from `init()` (panic OK — embedded data is part of the build) **and** from every public lookup. The hot-reload mechanism documented in `hub/README.md` — `kubectl cp` a YAML into the pod's `/tmp/hub/<kind>/`, write to the trigger file — would therefore kill the running api-server from the first caller after a bad YAML was dropped.
- Build into a temporary map per loader. Swap into the package globals only when the walk succeeds. On reload failure, `klog.ErrorS` and keep the previous map. The first-load case (package globals still nil) still panics so `init()` crashes loud if embedded data is malformed.

## Test plan
- [ ] `make unit-tests`
- [ ] Drop a syntactically broken YAML into `/tmp/hub/resourcedescriptors/`, touch the trigger file, and confirm the api-server logs an error and keeps serving the previous descriptors instead of crashing.
- [ ] Confirm `init()` still panics when an embedded YAML is intentionally corrupted (use `go build -tags fault` style if needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)