### PR TITLE
ui-updater: log digest resolution failures instead of exiting

### DIFF
--- a/cmd/ui-updater/main.go
+++ b/cmd/ui-updater/main.go
@@ -196,11 +196,8 @@ func getDigestOrVersion(repo, bin, ver string) string {
 	ref := fmt.Sprintf("ghcr.io/appscode-charts/%s:%s", bin, ver)
 	digest, err := crane.Digest(ref, crane.WithAuthFromKeychain(authn.DefaultKeychain))
 	if err != nil {
-		// Don't silently downgrade from a pinned digest to a mutable tag —
-		// surface the failure so the operator can decide whether to retry
-		// or accept the un-pinned version.
-		fmt.Fprintf(os.Stderr, "ERROR: failed to resolve digest for %s: %v\n", ref, err)
-		os.Exit(1)
+		fmt.Fprintf(os.Stderr, "WARN: failed to resolve digest for %s: %v\n", ref, err)
+		return ver
 	}
 	return digest
 }


### PR DESCRIPTION
## Summary
- Reverts the hard-fail behavior introduced in #628. `getDigestOrVersion` in `cmd/ui-updater/main.go` no longer exits when `crane.Digest` fails — it now logs a `WARN` to stderr and falls back to the plain version tag so a transient registry/auth blip doesn't abort the whole refresh run.

## Test plan
- [ ] Run `go run ./cmd/ui-updater --use-digest` with valid auth → digests resolved as before.
- [ ] Point at an unreachable ref → tool logs the failure and continues with the tag version instead of exiting non-zero.