### PR TITLE
ui-updater: exit on digest failure, skip templated chart names

### DIFF
--- a/cmd/ui-updater/main.go
+++ b/cmd/ui-updater/main.go
@@ -21,6 +21,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
 	kmapi "kmodules.xyz/client-go/api/v1"
 	uiapi "kmodules.xyz/resource-metadata/apis/ui/v1alpha1"
@@ -204,11 +205,17 @@ func getDigestOrVersion(repo, bin, ver string) string {
 	if repo != "appscode-charts-oci" {
 		return ver
 	}
+	// Skip digest resolution for templated chart names (e.g.
+	// uik8sappscodecom-featureset-{.metadata.release.name}-editor) — the
+	// chart name is only resolved at render time, so no fixed digest exists.
+	if strings.ContainsAny(bin, "{}") {
+		return ver
+	}
 	ref := fmt.Sprintf("ghcr.io/appscode-charts/%s:%s", bin, ver)
 	digest, err := crane.Digest(ref, crane.WithAuthFromKeychain(authn.DefaultKeychain))
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "WARN: failed to resolve digest for %s: %v\n", ref, err)
-		return ver
+		fmt.Fprintf(os.Stderr, "ERROR: failed to resolve digest for %s: %v\n", ref, err)
+		os.Exit(1)
 	}
 	return digest
 }


### PR DESCRIPTION
## Summary

- Restore the strict behavior from #628: `ui-updater` exits non-zero when `crane.Digest` fails, instead of silently falling back to the mutable tag (current behavior from #640).
- Add an exception for templated chart names — when `bin` contains `{` or `}` (e.g. `uik8sappscodecom-featureset-{.metadata.release.name}-editor`), skip the digest lookup and emit the version tag, since the chart name is only resolved at render time.

## Test plan

- [ ] `make build` succeeds
- [ ] Run `./ui-updater` against `hub/resourceeditors/`; verify featureset entries (templated names) are written with the version tag and no error, while other entries get a digest as before
- [ ] Simulate a digest failure (e.g. invalid version) and confirm the process exits non-zero with an `ERROR:` message