### PR TITLE
Rename helm repository to appscode-wizards-oci

### DIFF
--- a/hub/resourceeditors/acme.cert-manager.io/v1/challenges.yaml
+++ b/hub/resourceeditors/acme.cert-manager.io/v1/challenges.yaml
@@ -33,6 +33,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/acme.cert-manager.io/v1/orders.yaml
+++ b/hub/resourceeditors/acme.cert-manager.io/v1/orders.yaml
@@ -33,6 +33,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/addon.open-cluster-management.io/v1alpha1/addondeploymentconfigs.yaml
+++ b/hub/resourceeditors/addon.open-cluster-management.io/v1alpha1/addondeploymentconfigs.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/addon.open-cluster-management.io/v1alpha1/addontemplates.yaml
+++ b/hub/resourceeditors/addon.open-cluster-management.io/v1alpha1/addontemplates.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/addon.open-cluster-management.io/v1alpha1/clustermanagementaddons.yaml
+++ b/hub/resourceeditors/addon.open-cluster-management.io/v1alpha1/clustermanagementaddons.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/addon.open-cluster-management.io/v1alpha1/managedclusteraddons.yaml
+++ b/hub/resourceeditors/addon.open-cluster-management.io/v1alpha1/managedclusteraddons.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/addons.cluster.x-k8s.io/v1beta1/clusterresourcesetbindings.yaml
+++ b/hub/resourceeditors/addons.cluster.x-k8s.io/v1beta1/clusterresourcesetbindings.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/addons.cluster.x-k8s.io/v1beta1/clusterresourcesets.yaml
+++ b/hub/resourceeditors/addons.cluster.x-k8s.io/v1beta1/clusterresourcesets.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/addons.kubestash.com/v1alpha1/addons.yaml
+++ b/hub/resourceeditors/addons.kubestash.com/v1alpha1/addons.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/addons.kubestash.com/v1alpha1/functions.yaml
+++ b/hub/resourceeditors/addons.kubestash.com/v1alpha1/functions.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations.yaml
+++ b/hub/resourceeditors/admissionregistration.k8s.io/v1/mutatingwebhookconfigurations.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/admissionregistration.k8s.io/v1/validatingwebhookconfigurations.yaml
+++ b/hub/resourceeditors/admissionregistration.k8s.io/v1/validatingwebhookconfigurations.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/apiextensions.crossplane.io/v1/compositeresourcedefinitions.yaml
+++ b/hub/resourceeditors/apiextensions.crossplane.io/v1/compositeresourcedefinitions.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/apiextensions.crossplane.io/v1/compositionrevisions.yaml
+++ b/hub/resourceeditors/apiextensions.crossplane.io/v1/compositionrevisions.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/apiextensions.crossplane.io/v1/compositions.yaml
+++ b/hub/resourceeditors/apiextensions.crossplane.io/v1/compositions.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/apiextensions.crossplane.io/v1alpha1/environmentconfigs.yaml
+++ b/hub/resourceeditors/apiextensions.crossplane.io/v1alpha1/environmentconfigs.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/apiextensions.k8s.io/v1/customresourcedefinitions.yaml
+++ b/hub/resourceeditors/apiextensions.k8s.io/v1/customresourcedefinitions.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/apiregistration.k8s.io/v1/apiservices.yaml
+++ b/hub/resourceeditors/apiregistration.k8s.io/v1/apiservices.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/app.k8s.io/v1beta1/applications.yaml
+++ b/hub/resourceeditors/app.k8s.io/v1beta1/applications.yaml
@@ -20,7 +20,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false
     instanceLabelPaths:

--- a/hub/resourceeditors/appcatalog.appscode.com/v1alpha1/appbindings.yaml
+++ b/hub/resourceeditors/appcatalog.appscode.com/v1alpha1/appbindings.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/apps.k8s.appscode.com/v1/petsets.yaml
+++ b/hub/resourceeditors/apps.k8s.appscode.com/v1/petsets.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/apps.k8s.appscode.com/v1/placementpolicies.yaml
+++ b/hub/resourceeditors/apps.k8s.appscode.com/v1/placementpolicies.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/apps/v1/daemonsets.yaml
+++ b/hub/resourceeditors/apps/v1/daemonsets.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/apps/v1/deployments.yaml
+++ b/hub/resourceeditors/apps/v1/deployments.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/apps/v1/replicasets.yaml
+++ b/hub/resourceeditors/apps/v1/replicasets.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/apps/v1/statefulsets.yaml
+++ b/hub/resourceeditors/apps/v1/statefulsets.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/archiver.kubedb.com/v1alpha1/clickhousearchivers.yaml
+++ b/hub/resourceeditors/archiver.kubedb.com/v1alpha1/clickhousearchivers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/archiver.kubedb.com/v1alpha1/mariadbarchivers.yaml
+++ b/hub/resourceeditors/archiver.kubedb.com/v1alpha1/mariadbarchivers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/archiver.kubedb.com/v1alpha1/mongodbarchivers.yaml
+++ b/hub/resourceeditors/archiver.kubedb.com/v1alpha1/mongodbarchivers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/archiver.kubedb.com/v1alpha1/mssqlserverarchivers.yaml
+++ b/hub/resourceeditors/archiver.kubedb.com/v1alpha1/mssqlserverarchivers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/archiver.kubedb.com/v1alpha1/mysqlarchivers.yaml
+++ b/hub/resourceeditors/archiver.kubedb.com/v1alpha1/mysqlarchivers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/archiver.kubedb.com/v1alpha1/postgresarchivers.yaml
+++ b/hub/resourceeditors/archiver.kubedb.com/v1alpha1/postgresarchivers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/auditregistration.k8s.io/v1alpha1/auditsinks.yaml
+++ b/hub/resourceeditors/auditregistration.k8s.io/v1alpha1/auditsinks.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/authentication.k8s.appscode.com/v1alpha1/accounts.yaml
+++ b/hub/resourceeditors/authentication.k8s.appscode.com/v1alpha1/accounts.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/authentication.k8s.appscode.com/v1alpha1/users.yaml
+++ b/hub/resourceeditors/authentication.k8s.appscode.com/v1alpha1/users.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/authentication.open-cluster-management.io/v1beta1/managedserviceaccounts.yaml
+++ b/hub/resourceeditors/authentication.open-cluster-management.io/v1beta1/managedserviceaccounts.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/authorization.azure.kubedb.com/v1alpha1/roleassignments.yaml
+++ b/hub/resourceeditors/authorization.azure.kubedb.com/v1alpha1/roleassignments.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/authorization.k8s.appscode.com/v1alpha1/managedclusterrolebindings.yaml
+++ b/hub/resourceeditors/authorization.k8s.appscode.com/v1alpha1/managedclusterrolebindings.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/authorization.k8s.appscode.com/v1alpha1/managedclusterroles.yaml
+++ b/hub/resourceeditors/authorization.k8s.appscode.com/v1alpha1/managedclusterroles.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/authorization.k8s.appscode.com/v1alpha1/managedclustersetrolebindings.yaml
+++ b/hub/resourceeditors/authorization.k8s.appscode.com/v1alpha1/managedclustersetrolebindings.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/autoscaling.k8s.io/v1/verticalpodautoscalercheckpoints.yaml
+++ b/hub/resourceeditors/autoscaling.k8s.io/v1/verticalpodautoscalercheckpoints.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/autoscaling.k8s.io/v1/verticalpodautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.k8s.io/v1/verticalpodautoscalers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/cassandraautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/cassandraautoscalers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/clickhouseautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/clickhouseautoscalers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/documentdbautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/documentdbautoscalers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/druidautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/druidautoscalers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/elasticsearchautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/elasticsearchautoscalers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/etcdautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/etcdautoscalers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/hanadbautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/hanadbautoscalers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/hazelcastautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/hazelcastautoscalers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/igniteautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/igniteautoscalers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/kafkaautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/kafkaautoscalers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mariadbautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mariadbautoscalers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/memcachedautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/memcachedautoscalers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/milvusautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/milvusautoscalers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mongodbautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mongodbautoscalers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mssqlserverautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mssqlserverautoscalers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mysqlautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/mysqlautoscalers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/neo4jautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/neo4jautoscalers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/oracleautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/oracleautoscalers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/perconaxtradbautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/perconaxtradbautoscalers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/pgbouncerautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/pgbouncerautoscalers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/pgpoolautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/pgpoolautoscalers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/postgresautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/postgresautoscalers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/proxysqlautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/proxysqlautoscalers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/qdrantautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/qdrantautoscalers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/rabbitmqautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/rabbitmqautoscalers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/redisautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/redisautoscalers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/redissentinelautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/redissentinelautoscalers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/singlestoreautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/singlestoreautoscalers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/solrautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/solrautoscalers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/weaviateautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/weaviateautoscalers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/zookeeperautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling.kubedb.com/v1alpha1/zookeeperautoscalers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/autoscaling/v2beta2/horizontalpodautoscalers.yaml
+++ b/hub/resourceeditors/autoscaling/v2beta2/horizontalpodautoscalers.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/aws.kubedb.com/v1alpha1/storeconfigs.yaml
+++ b/hub/resourceeditors/aws.kubedb.com/v1alpha1/storeconfigs.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/aws.kubedb.com/v1beta1/providerconfigs.yaml
+++ b/hub/resourceeditors/aws.kubedb.com/v1beta1/providerconfigs.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/aws.kubedb.com/v1beta1/providerconfigusages.yaml
+++ b/hub/resourceeditors/aws.kubedb.com/v1beta1/providerconfigusages.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/azure.kubedb.com/v1alpha1/providerregistrations.yaml
+++ b/hub/resourceeditors/azure.kubedb.com/v1alpha1/providerregistrations.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/azure.kubedb.com/v1alpha1/resourcegroups.yaml
+++ b/hub/resourceeditors/azure.kubedb.com/v1alpha1/resourcegroups.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/azure.kubedb.com/v1alpha1/storeconfigs.yaml
+++ b/hub/resourceeditors/azure.kubedb.com/v1alpha1/storeconfigs.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/azure.kubedb.com/v1alpha1/subscriptions.yaml
+++ b/hub/resourceeditors/azure.kubedb.com/v1alpha1/subscriptions.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/azure.kubedb.com/v1beta1/providerconfigs.yaml
+++ b/hub/resourceeditors/azure.kubedb.com/v1beta1/providerconfigs.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/azure.kubedb.com/v1beta1/providerconfigusages.yaml
+++ b/hub/resourceeditors/azure.kubedb.com/v1beta1/providerconfigusages.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/batch.k8s.appscode.com/v1alpha1/pendingtasks.yaml
+++ b/hub/resourceeditors/batch.k8s.appscode.com/v1alpha1/pendingtasks.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/batch.k8s.appscode.com/v1alpha1/taskqueues.yaml
+++ b/hub/resourceeditors/batch.k8s.appscode.com/v1alpha1/taskqueues.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/batch/v1/cronjobs.yaml
+++ b/hub/resourceeditors/batch/v1/cronjobs.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/batch/v1/jobs.yaml
+++ b/hub/resourceeditors/batch/v1/jobs.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/batch/v1beta1/cronjobs.yaml
+++ b/hub/resourceeditors/batch/v1beta1/cronjobs.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/bootstrap.cluster.x-k8s.io/v1beta2/eksconfigs.yaml
+++ b/hub/resourceeditors/bootstrap.cluster.x-k8s.io/v1beta2/eksconfigs.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/bootstrap.cluster.x-k8s.io/v1beta2/eksconfigtemplates.yaml
+++ b/hub/resourceeditors/bootstrap.cluster.x-k8s.io/v1beta2/eksconfigtemplates.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cache.azure.kubedb.com/v1alpha1/rediscaches.yaml
+++ b/hub/resourceeditors/cache.azure.kubedb.com/v1alpha1/rediscaches.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cache.azure.kubedb.com/v1alpha1/redisenterpriseclusters.yaml
+++ b/hub/resourceeditors/cache.azure.kubedb.com/v1alpha1/redisenterpriseclusters.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cache.azure.kubedb.com/v1alpha1/redisenterprisedatabases.yaml
+++ b/hub/resourceeditors/cache.azure.kubedb.com/v1alpha1/redisenterprisedatabases.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cache.azure.kubedb.com/v1alpha1/redisfirewallrules.yaml
+++ b/hub/resourceeditors/cache.azure.kubedb.com/v1alpha1/redisfirewallrules.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cache.azure.kubedb.com/v1alpha1/redislinkedservers.yaml
+++ b/hub/resourceeditors/cache.azure.kubedb.com/v1alpha1/redislinkedservers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.appscode.com/v1alpha1/cassandrabindings.yaml
+++ b/hub/resourceeditors/catalog.appscode.com/v1alpha1/cassandrabindings.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.appscode.com/v1alpha1/clickhousebindings.yaml
+++ b/hub/resourceeditors/catalog.appscode.com/v1alpha1/clickhousebindings.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.appscode.com/v1alpha1/druidbindings.yaml
+++ b/hub/resourceeditors/catalog.appscode.com/v1alpha1/druidbindings.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.appscode.com/v1alpha1/elasticsearchbindings.yaml
+++ b/hub/resourceeditors/catalog.appscode.com/v1alpha1/elasticsearchbindings.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.appscode.com/v1alpha1/ferretdbbindings.yaml
+++ b/hub/resourceeditors/catalog.appscode.com/v1alpha1/ferretdbbindings.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.appscode.com/v1alpha1/hazelcastbindings.yaml
+++ b/hub/resourceeditors/catalog.appscode.com/v1alpha1/hazelcastbindings.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.appscode.com/v1alpha1/kafkabindings.yaml
+++ b/hub/resourceeditors/catalog.appscode.com/v1alpha1/kafkabindings.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.appscode.com/v1alpha1/mariadbbindings.yaml
+++ b/hub/resourceeditors/catalog.appscode.com/v1alpha1/mariadbbindings.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.appscode.com/v1alpha1/memcachedbindings.yaml
+++ b/hub/resourceeditors/catalog.appscode.com/v1alpha1/memcachedbindings.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.appscode.com/v1alpha1/mongodbbindings.yaml
+++ b/hub/resourceeditors/catalog.appscode.com/v1alpha1/mongodbbindings.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.appscode.com/v1alpha1/mssqlserverbindings.yaml
+++ b/hub/resourceeditors/catalog.appscode.com/v1alpha1/mssqlserverbindings.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.appscode.com/v1alpha1/mysqlbindings.yaml
+++ b/hub/resourceeditors/catalog.appscode.com/v1alpha1/mysqlbindings.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.appscode.com/v1alpha1/oraclebindings.yaml
+++ b/hub/resourceeditors/catalog.appscode.com/v1alpha1/oraclebindings.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.appscode.com/v1alpha1/perconaxtradbbindings.yaml
+++ b/hub/resourceeditors/catalog.appscode.com/v1alpha1/perconaxtradbbindings.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.appscode.com/v1alpha1/pgbouncerbindings.yaml
+++ b/hub/resourceeditors/catalog.appscode.com/v1alpha1/pgbouncerbindings.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.appscode.com/v1alpha1/pgpoolbindings.yaml
+++ b/hub/resourceeditors/catalog.appscode.com/v1alpha1/pgpoolbindings.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.appscode.com/v1alpha1/postgresbindings.yaml
+++ b/hub/resourceeditors/catalog.appscode.com/v1alpha1/postgresbindings.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.appscode.com/v1alpha1/proxysqlbindings.yaml
+++ b/hub/resourceeditors/catalog.appscode.com/v1alpha1/proxysqlbindings.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.appscode.com/v1alpha1/rabbitmqbindings.yaml
+++ b/hub/resourceeditors/catalog.appscode.com/v1alpha1/rabbitmqbindings.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.appscode.com/v1alpha1/redisbindings.yaml
+++ b/hub/resourceeditors/catalog.appscode.com/v1alpha1/redisbindings.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.appscode.com/v1alpha1/singlestorebindings.yaml
+++ b/hub/resourceeditors/catalog.appscode.com/v1alpha1/singlestorebindings.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.appscode.com/v1alpha1/solrbindings.yaml
+++ b/hub/resourceeditors/catalog.appscode.com/v1alpha1/solrbindings.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.appscode.com/v1alpha1/zookeeperbindings.yaml
+++ b/hub/resourceeditors/catalog.appscode.com/v1alpha1/zookeeperbindings.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/aerospikeversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/aerospikeversions.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/cassandraversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/cassandraversions.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/clickhouseversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/clickhouseversions.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/db2versions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/db2versions.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/documentdbversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/documentdbversions.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/druidversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/druidversions.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/elasticsearchversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/elasticsearchversions.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/etcdversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/etcdversions.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/hanadbversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/hanadbversions.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/hazelcastversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/hazelcastversions.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/igniteversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/igniteversions.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/kafkaconnectorversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/kafkaconnectorversions.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/kafkaversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/kafkaversions.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mariadbversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mariadbversions.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/memcachedversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/memcachedversions.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/milvusversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/milvusversions.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mongodbversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mongodbversions.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mssqlserverversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mssqlserverversions.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mysqlversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/mysqlversions.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/neo4jversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/neo4jversions.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/oracleversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/oracleversions.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/perconaxtradbversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/perconaxtradbversions.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/pgbouncerversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/pgbouncerversions.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/pgpoolversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/pgpoolversions.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/postgresversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/postgresversions.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/proxysqlversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/proxysqlversions.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/qdrantversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/qdrantversions.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/rabbitmqversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/rabbitmqversions.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/redisversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/redisversions.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/schemaregistryversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/schemaregistryversions.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/singlestoreversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/singlestoreversions.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/solrversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/solrversions.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/weaviateversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/weaviateversions.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubedb.com/v1alpha1/zookeeperversions.yaml
+++ b/hub/resourceeditors/catalog.kubedb.com/v1alpha1/zookeeperversions.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubevault.com/v1alpha1/vaultserverversions.yaml
+++ b/hub/resourceeditors/catalog.kubevault.com/v1alpha1/vaultserverversions.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/elasticsearchbindings.yaml
+++ b/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/elasticsearchbindings.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/kafkabindings.yaml
+++ b/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/kafkabindings.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/mariadbbindings.yaml
+++ b/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/mariadbbindings.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/memcachedbindings.yaml
+++ b/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/memcachedbindings.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/mongodbbindings.yaml
+++ b/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/mongodbbindings.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/mysqlbindings.yaml
+++ b/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/mysqlbindings.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/perconaxtradbbindings.yaml
+++ b/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/perconaxtradbbindings.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/pgbouncerbindings.yaml
+++ b/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/pgbouncerbindings.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/postgresbindings.yaml
+++ b/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/postgresbindings.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/proxysqlbindings.yaml
+++ b/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/proxysqlbindings.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/redisbindings.yaml
+++ b/hub/resourceeditors/catalog.kubeware.dev/v1alpha1/redisbindings.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cert-manager.io/v1/certificaterequests.yaml
+++ b/hub/resourceeditors/cert-manager.io/v1/certificaterequests.yaml
@@ -33,6 +33,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cert-manager.io/v1/certificates.yaml
+++ b/hub/resourceeditors/cert-manager.io/v1/certificates.yaml
@@ -33,6 +33,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cert-manager.io/v1/clusterissuers.yaml
+++ b/hub/resourceeditors/cert-manager.io/v1/clusterissuers.yaml
@@ -33,6 +33,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cert-manager.io/v1/issuers.yaml
+++ b/hub/resourceeditors/cert-manager.io/v1/issuers.yaml
@@ -33,6 +33,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/certificates.k8s.io/v1/certificatesigningrequests.yaml
+++ b/hub/resourceeditors/certificates.k8s.io/v1/certificatesigningrequests.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/certificates.k8s.io/v1beta1/certificatesigningrequests.yaml
+++ b/hub/resourceeditors/certificates.k8s.io/v1beta1/certificatesigningrequests.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/charts.x-helm.dev/v1alpha1/chartpresets.yaml
+++ b/hub/resourceeditors/charts.x-helm.dev/v1alpha1/chartpresets.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/charts.x-helm.dev/v1alpha1/clusterchartpresets.yaml
+++ b/hub/resourceeditors/charts.x-helm.dev/v1alpha1/clusterchartpresets.yaml
@@ -20,7 +20,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false
     options:
@@ -28,5 +28,5 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0

--- a/hub/resourceeditors/cluster.open-cluster-management.io/v1/managedclusters.yaml
+++ b/hub/resourceeditors/cluster.open-cluster-management.io/v1/managedclusters.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cluster.open-cluster-management.io/v1alpha1/addonplacementscores.yaml
+++ b/hub/resourceeditors/cluster.open-cluster-management.io/v1alpha1/addonplacementscores.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cluster.open-cluster-management.io/v1alpha1/clusterclaims.yaml
+++ b/hub/resourceeditors/cluster.open-cluster-management.io/v1alpha1/clusterclaims.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cluster.open-cluster-management.io/v1beta1/placementdecisions.yaml
+++ b/hub/resourceeditors/cluster.open-cluster-management.io/v1beta1/placementdecisions.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cluster.open-cluster-management.io/v1beta1/placements.yaml
+++ b/hub/resourceeditors/cluster.open-cluster-management.io/v1beta1/placements.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cluster.open-cluster-management.io/v1beta2/managedclustersetbindings.yaml
+++ b/hub/resourceeditors/cluster.open-cluster-management.io/v1beta2/managedclustersetbindings.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cluster.open-cluster-management.io/v1beta2/managedclustersets.yaml
+++ b/hub/resourceeditors/cluster.open-cluster-management.io/v1beta2/managedclustersets.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cluster.x-k8s.io/v1alpha3/machines.yaml
+++ b/hub/resourceeditors/cluster.x-k8s.io/v1alpha3/machines.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cluster.x-k8s.io/v1alpha3/machinesets.yaml
+++ b/hub/resourceeditors/cluster.x-k8s.io/v1alpha3/machinesets.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cluster.x-k8s.io/v1beta1/clusterclasses.yaml
+++ b/hub/resourceeditors/cluster.x-k8s.io/v1beta1/clusterclasses.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cluster.x-k8s.io/v1beta1/clusters.yaml
+++ b/hub/resourceeditors/cluster.x-k8s.io/v1beta1/clusters.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machinedeployments.yaml
+++ b/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machinedeployments.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machinehealthchecks.yaml
+++ b/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machinehealthchecks.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machinepools.yaml
+++ b/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machinepools.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machines.yaml
+++ b/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machines.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machinesets.yaml
+++ b/hub/resourceeditors/cluster.x-k8s.io/v1beta1/machinesets.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/compute.gcp.kubedb.com/v1alpha1/firewalls.yaml
+++ b/hub/resourceeditors/compute.gcp.kubedb.com/v1alpha1/firewalls.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/compute.gcp.kubedb.com/v1alpha1/networkpeerings.yaml
+++ b/hub/resourceeditors/compute.gcp.kubedb.com/v1alpha1/networkpeerings.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/compute.gcp.kubedb.com/v1alpha1/networks.yaml
+++ b/hub/resourceeditors/compute.gcp.kubedb.com/v1alpha1/networks.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/config.gatekeeper.sh/v1alpha1/configs.yaml
+++ b/hub/resourceeditors/config.gatekeeper.sh/v1alpha1/configs.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/config.gateway.envoyproxy.io/v1alpha1/envoyproxies.yaml
+++ b/hub/resourceeditors/config.gateway.envoyproxy.io/v1alpha1/envoyproxies.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/config.gateway.open-cluster-management.io/v1alpha1/clustergatewayconfigurations.yaml
+++ b/hub/resourceeditors/config.gateway.open-cluster-management.io/v1alpha1/clustergatewayconfigurations.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/config.virtual-secrets.dev/v1alpha1/secretmetadatas.yaml
+++ b/hub/resourceeditors/config.virtual-secrets.dev/v1alpha1/secretmetadatas.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/config.virtual-secrets.dev/v1alpha1/secretstores.yaml
+++ b/hub/resourceeditors/config.virtual-secrets.dev/v1alpha1/secretstores.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/controlplane.cluster.x-k8s.io/v1beta2/awsmanagedcontrolplanes.yaml
+++ b/hub/resourceeditors/controlplane.cluster.x-k8s.io/v1beta2/awsmanagedcontrolplanes.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/controlplane.cluster.x-k8s.io/v1beta2/rosacontrolplanes.yaml
+++ b/hub/resourceeditors/controlplane.cluster.x-k8s.io/v1beta2/rosacontrolplanes.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/coordination.k8s.io/v1/leases.yaml
+++ b/hub/resourceeditors/coordination.k8s.io/v1/leases.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/genericresources.yaml
+++ b/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/genericresources.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/genericresourceservices.yaml
+++ b/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/genericresourceservices.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/podviews.yaml
+++ b/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/podviews.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/projects.yaml
+++ b/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/projects.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/resourcesummaries.yaml
+++ b/hub/resourceeditors/core.k8s.appscode.com/v1alpha1/resourcesummaries.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/core.kubestash.com/v1alpha1/backupbatches.yaml
+++ b/hub/resourceeditors/core.kubestash.com/v1alpha1/backupbatches.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/core.kubestash.com/v1alpha1/backupblueprints.yaml
+++ b/hub/resourceeditors/core.kubestash.com/v1alpha1/backupblueprints.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/core.kubestash.com/v1alpha1/backupconfigurations.yaml
+++ b/hub/resourceeditors/core.kubestash.com/v1alpha1/backupconfigurations.yaml
@@ -25,7 +25,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false
     options:
@@ -33,5 +33,5 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0

--- a/hub/resourceeditors/core.kubestash.com/v1alpha1/backupsessions.yaml
+++ b/hub/resourceeditors/core.kubestash.com/v1alpha1/backupsessions.yaml
@@ -25,7 +25,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false
     options:
@@ -33,5 +33,5 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0

--- a/hub/resourceeditors/core.kubestash.com/v1alpha1/backupverificationsession.yaml
+++ b/hub/resourceeditors/core.kubestash.com/v1alpha1/backupverificationsession.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/core.kubestash.com/v1alpha1/backupverifier.yaml
+++ b/hub/resourceeditors/core.kubestash.com/v1alpha1/backupverifier.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/core.kubestash.com/v1alpha1/hooktemplates.yaml
+++ b/hub/resourceeditors/core.kubestash.com/v1alpha1/hooktemplates.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/core.kubestash.com/v1alpha1/restoresessions.yaml
+++ b/hub/resourceeditors/core.kubestash.com/v1alpha1/restoresessions.yaml
@@ -25,7 +25,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false
     options:
@@ -33,5 +33,5 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0

--- a/hub/resourceeditors/core/v1/bindings.yaml
+++ b/hub/resourceeditors/core/v1/bindings.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/core/v1/componentstatuses.yaml
+++ b/hub/resourceeditors/core/v1/componentstatuses.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/core/v1/configmaps.yaml
+++ b/hub/resourceeditors/core/v1/configmaps.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/core/v1/endpoints.yaml
+++ b/hub/resourceeditors/core/v1/endpoints.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/core/v1/ephemeralcontainers.yaml
+++ b/hub/resourceeditors/core/v1/ephemeralcontainers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/core/v1/events.yaml
+++ b/hub/resourceeditors/core/v1/events.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/core/v1/limitranges.yaml
+++ b/hub/resourceeditors/core/v1/limitranges.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/core/v1/namespaces.yaml
+++ b/hub/resourceeditors/core/v1/namespaces.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/core/v1/nodes.yaml
+++ b/hub/resourceeditors/core/v1/nodes.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/core/v1/persistentvolumeclaims.yaml
+++ b/hub/resourceeditors/core/v1/persistentvolumeclaims.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/core/v1/persistentvolumes.yaml
+++ b/hub/resourceeditors/core/v1/persistentvolumes.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/core/v1/pods.yaml
+++ b/hub/resourceeditors/core/v1/pods.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/core/v1/podstatusresults.yaml
+++ b/hub/resourceeditors/core/v1/podstatusresults.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/core/v1/rangeallocations.yaml
+++ b/hub/resourceeditors/core/v1/rangeallocations.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/core/v1/replicationcontrollers.yaml
+++ b/hub/resourceeditors/core/v1/replicationcontrollers.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/core/v1/resourcequotas.yaml
+++ b/hub/resourceeditors/core/v1/resourcequotas.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/core/v1/secrets.yaml
+++ b/hub/resourceeditors/core/v1/secrets.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/core/v1/serviceaccounts.yaml
+++ b/hub/resourceeditors/core/v1/serviceaccounts.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/core/v1/services.yaml
+++ b/hub/resourceeditors/core/v1/services.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/accounts.yaml
+++ b/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/accounts.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/cassandraclusters.yaml
+++ b/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/cassandraclusters.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/cassandradatacenters.yaml
+++ b/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/cassandradatacenters.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/cassandrakeyspaces.yaml
+++ b/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/cassandrakeyspaces.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/cassandratables.yaml
+++ b/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/cassandratables.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/gremlindatabases.yaml
+++ b/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/gremlindatabases.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/gremlingraphs.yaml
+++ b/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/gremlingraphs.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/mongocollections.yaml
+++ b/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/mongocollections.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/mongodatabases.yaml
+++ b/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/mongodatabases.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqlcontainers.yaml
+++ b/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqlcontainers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqldatabases.yaml
+++ b/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqldatabases.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqldedicatedgateways.yaml
+++ b/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqldedicatedgateways.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqlfunctions.yaml
+++ b/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqlfunctions.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqlroleassignments.yaml
+++ b/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqlroleassignments.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqlroledefinitions.yaml
+++ b/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqlroledefinitions.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqlstoredprocedures.yaml
+++ b/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqlstoredprocedures.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqltriggers.yaml
+++ b/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/sqltriggers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/tables.yaml
+++ b/hub/resourceeditors/cosmosdb.azure.kubedb.com/v1alpha1/tables.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/dbformariadb.azure.kubedb.com/v1alpha1/configurations.yaml
+++ b/hub/resourceeditors/dbformariadb.azure.kubedb.com/v1alpha1/configurations.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/dbformariadb.azure.kubedb.com/v1alpha1/databases.yaml
+++ b/hub/resourceeditors/dbformariadb.azure.kubedb.com/v1alpha1/databases.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/dbformariadb.azure.kubedb.com/v1alpha1/firewallrules.yaml
+++ b/hub/resourceeditors/dbformariadb.azure.kubedb.com/v1alpha1/firewallrules.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/dbformariadb.azure.kubedb.com/v1alpha1/servers.yaml
+++ b/hub/resourceeditors/dbformariadb.azure.kubedb.com/v1alpha1/servers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/dbformariadb.azure.kubedb.com/v1alpha1/virtualnetworkrules.yaml
+++ b/hub/resourceeditors/dbformariadb.azure.kubedb.com/v1alpha1/virtualnetworkrules.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/activedirectoryadministrators.yaml
+++ b/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/activedirectoryadministrators.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/configurations.yaml
+++ b/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/configurations.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/databases.yaml
+++ b/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/databases.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/firewallrules.yaml
+++ b/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/firewallrules.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/flexibledatabases.yaml
+++ b/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/flexibledatabases.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/flexibleserverconfigurations.yaml
+++ b/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/flexibleserverconfigurations.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/flexibleserverfirewallrules.yaml
+++ b/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/flexibleserverfirewallrules.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/flexibleservers.yaml
+++ b/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/flexibleservers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/servers.yaml
+++ b/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/servers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/virtualnetworkrules.yaml
+++ b/hub/resourceeditors/dbformysql.azure.kubedb.com/v1alpha1/virtualnetworkrules.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/activedirectoryadministrators.yaml
+++ b/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/activedirectoryadministrators.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/configurations.yaml
+++ b/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/configurations.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/databases.yaml
+++ b/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/databases.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/firewallrules.yaml
+++ b/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/firewallrules.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/flexibleserverconfigurations.yaml
+++ b/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/flexibleserverconfigurations.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/flexibleserverdatabases.yaml
+++ b/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/flexibleserverdatabases.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/flexibleserverfirewallrules.yaml
+++ b/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/flexibleserverfirewallrules.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/flexibleservers.yaml
+++ b/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/flexibleservers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/serverkeys.yaml
+++ b/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/serverkeys.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/servers.yaml
+++ b/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/servers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/virtualnetworkrules.yaml
+++ b/hub/resourceeditors/dbforpostgresql.azure.kubedb.com/v1alpha1/virtualnetworkrules.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/discovery.k8s.io/v1/endpointslice.yaml
+++ b/hub/resourceeditors/discovery.k8s.io/v1/endpointslice.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/discovery.k8s.io/v1beta1/endpointslice.yaml
+++ b/hub/resourceeditors/discovery.k8s.io/v1beta1/endpointslice.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/discovery.k8s.io/v1beta1/endpointslices.yaml
+++ b/hub/resourceeditors/discovery.k8s.io/v1beta1/endpointslices.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/clusterinstances.yaml
+++ b/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/clusterinstances.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/clusterparametergroups.yaml
+++ b/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/clusterparametergroups.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/clusters.yaml
+++ b/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/clusters.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/clustersnapshots.yaml
+++ b/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/clustersnapshots.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/eventsubscriptions.yaml
+++ b/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/eventsubscriptions.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/globalclusters.yaml
+++ b/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/globalclusters.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/subnetgroups.yaml
+++ b/hub/resourceeditors/docdb.aws.kubedb.com/v1alpha1/subnetgroups.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/drivers.x-helm.dev/v1alpha1/appreleases.yaml
+++ b/hub/resourceeditors/drivers.x-helm.dev/v1alpha1/appreleases.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/contributorinsights.yaml
+++ b/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/contributorinsights.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/globaltables.yaml
+++ b/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/globaltables.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/kinesisstreamingdestinations.yaml
+++ b/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/kinesisstreamingdestinations.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/tableitems.yaml
+++ b/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/tableitems.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/tablereplicas.yaml
+++ b/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/tablereplicas.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/tables.yaml
+++ b/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/tables.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/tags.yaml
+++ b/hub/resourceeditors/dynamodb.aws.kubedb.com/v1alpha1/tags.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/routes.yaml
+++ b/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/routes.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/securitygrouprules.yaml
+++ b/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/securitygrouprules.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/securitygroups.yaml
+++ b/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/securitygroups.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/subnets.yaml
+++ b/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/subnets.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/vpcendpoints.yaml
+++ b/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/vpcendpoints.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/vpcpeeringconnections.yaml
+++ b/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/vpcpeeringconnections.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/vpcs.yaml
+++ b/hub/resourceeditors/ec2.aws.kubedb.com/v1alpha1/vpcs.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/elasticache.aws.kubedb.com/v1alpha1/clusters.yaml
+++ b/hub/resourceeditors/elasticache.aws.kubedb.com/v1alpha1/clusters.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/elasticache.aws.kubedb.com/v1alpha1/parametergroups.yaml
+++ b/hub/resourceeditors/elasticache.aws.kubedb.com/v1alpha1/parametergroups.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/elasticache.aws.kubedb.com/v1alpha1/replicationgroups.yaml
+++ b/hub/resourceeditors/elasticache.aws.kubedb.com/v1alpha1/replicationgroups.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/elasticache.aws.kubedb.com/v1alpha1/subnetgroups.yaml
+++ b/hub/resourceeditors/elasticache.aws.kubedb.com/v1alpha1/subnetgroups.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/elasticache.aws.kubedb.com/v1alpha1/usergroups.yaml
+++ b/hub/resourceeditors/elasticache.aws.kubedb.com/v1alpha1/usergroups.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/elasticache.aws.kubedb.com/v1alpha1/users.yaml
+++ b/hub/resourceeditors/elasticache.aws.kubedb.com/v1alpha1/users.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/elasticsearch.aws.kubedb.com/v1alpha1/domainpolicies.yaml
+++ b/hub/resourceeditors/elasticsearch.aws.kubedb.com/v1alpha1/domainpolicies.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/elasticsearch.aws.kubedb.com/v1alpha1/domains.yaml
+++ b/hub/resourceeditors/elasticsearch.aws.kubedb.com/v1alpha1/domains.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/elasticsearch.aws.kubedb.com/v1alpha1/domainsamloptions.yaml
+++ b/hub/resourceeditors/elasticsearch.aws.kubedb.com/v1alpha1/domainsamloptions.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/elasticsearch.kubedb.com/v1alpha1/elasticsearchdashboards.yaml
+++ b/hub/resourceeditors/elasticsearch.kubedb.com/v1alpha1/elasticsearchdashboards.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/engine.kubevault.com/v1alpha1/awsroles.yaml
+++ b/hub/resourceeditors/engine.kubevault.com/v1alpha1/awsroles.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/engine.kubevault.com/v1alpha1/azureroles.yaml
+++ b/hub/resourceeditors/engine.kubevault.com/v1alpha1/azureroles.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/engine.kubevault.com/v1alpha1/elasticsearchroles.yaml
+++ b/hub/resourceeditors/engine.kubevault.com/v1alpha1/elasticsearchroles.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/engine.kubevault.com/v1alpha1/gcproles.yaml
+++ b/hub/resourceeditors/engine.kubevault.com/v1alpha1/gcproles.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/engine.kubevault.com/v1alpha1/mariadbroles.yaml
+++ b/hub/resourceeditors/engine.kubevault.com/v1alpha1/mariadbroles.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/engine.kubevault.com/v1alpha1/mongodbroles.yaml
+++ b/hub/resourceeditors/engine.kubevault.com/v1alpha1/mongodbroles.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/engine.kubevault.com/v1alpha1/mysqlroles.yaml
+++ b/hub/resourceeditors/engine.kubevault.com/v1alpha1/mysqlroles.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/engine.kubevault.com/v1alpha1/pkiroles.yaml
+++ b/hub/resourceeditors/engine.kubevault.com/v1alpha1/pkiroles.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/engine.kubevault.com/v1alpha1/postgresroles.yaml
+++ b/hub/resourceeditors/engine.kubevault.com/v1alpha1/postgresroles.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/engine.kubevault.com/v1alpha1/redisroles.yaml
+++ b/hub/resourceeditors/engine.kubevault.com/v1alpha1/redisroles.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretaccessrequests.yaml
+++ b/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretaccessrequests.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretengines.yaml
+++ b/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretengines.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretrolebindings.yaml
+++ b/hub/resourceeditors/engine.kubevault.com/v1alpha1/secretrolebindings.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/events.k8s.io/v1/events.yaml
+++ b/hub/resourceeditors/events.k8s.io/v1/events.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/events.k8s.io/v1beta1/events.yaml
+++ b/hub/resourceeditors/events.k8s.io/v1beta1/events.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/expansion.gatekeeper.sh/v1alpha1/expansiontemplate.yaml
+++ b/hub/resourceeditors/expansion.gatekeeper.sh/v1alpha1/expansiontemplate.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/extensions/v1beta1/daemonsets.yaml
+++ b/hub/resourceeditors/extensions/v1beta1/daemonsets.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/extensions/v1beta1/deployments.yaml
+++ b/hub/resourceeditors/extensions/v1beta1/deployments.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/extensions/v1beta1/ingresses.yaml
+++ b/hub/resourceeditors/extensions/v1beta1/ingresses.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/extensions/v1beta1/networkpolicies.yaml
+++ b/hub/resourceeditors/extensions/v1beta1/networkpolicies.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/extensions/v1beta1/podsecuritypolicies.yaml
+++ b/hub/resourceeditors/extensions/v1beta1/podsecuritypolicies.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/extensions/v1beta1/replicasets.yaml
+++ b/hub/resourceeditors/extensions/v1beta1/replicasets.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/extensions/v1beta1/scales.yaml
+++ b/hub/resourceeditors/extensions/v1beta1/scales.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/external-dns.appscode.com/v1alpha1/externaldns.yaml
+++ b/hub/resourceeditors/external-dns.appscode.com/v1alpha1/externaldns.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/falco.appscode.com/v1alpha1/falcoevents.yaml
+++ b/hub/resourceeditors/falco.appscode.com/v1alpha1/falcoevents.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1alpha1/flowschemas.yaml
+++ b/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1alpha1/flowschemas.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1alpha1/prioritylevelconfigurations.yaml
+++ b/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1alpha1/prioritylevelconfigurations.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1beta1/flowschemas.yaml
+++ b/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1beta1/flowschemas.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1beta1/prioritylevelconfigurations.yaml
+++ b/hub/resourceeditors/flowcontrol.apiserver.k8s.io/v1beta1/prioritylevelconfigurations.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/fluxcd.open-cluster-management.io/v1alpha1/fluxcdconfigs.yaml
+++ b/hub/resourceeditors/fluxcd.open-cluster-management.io/v1alpha1/fluxcdconfigs.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gateway.catalog.appscode.com/v1alpha1/gatewayconfigs.yaml
+++ b/hub/resourceeditors/gateway.catalog.appscode.com/v1alpha1/gatewayconfigs.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gateway.catalog.appscode.com/v1alpha1/gatewaypresets.yaml
+++ b/hub/resourceeditors/gateway.catalog.appscode.com/v1alpha1/gatewaypresets.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/authenticationfilters.yaml
+++ b/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/authenticationfilters.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/backends.yaml
+++ b/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/backends.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/backendtrafficpolicies.yaml
+++ b/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/backendtrafficpolicies.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/clienttrafficpolicies.yaml
+++ b/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/clienttrafficpolicies.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/envoyextensionpolicies.yaml
+++ b/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/envoyextensionpolicies.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/envoypatchpolicies.yaml
+++ b/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/envoypatchpolicies.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/envoyproxies.yaml
+++ b/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/envoyproxies.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/httproutefilters.yaml
+++ b/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/httproutefilters.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/ratelimitfilters.yaml
+++ b/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/ratelimitfilters.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/securitypolicies.yaml
+++ b/hub/resourceeditors/gateway.envoyproxy.io/v1alpha1/securitypolicies.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gateway.networking.k8s.io/v1/backendtlspolicies.yaml
+++ b/hub/resourceeditors/gateway.networking.k8s.io/v1/backendtlspolicies.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gateway.networking.k8s.io/v1/gatewayclasses.yaml
+++ b/hub/resourceeditors/gateway.networking.k8s.io/v1/gatewayclasses.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gateway.networking.k8s.io/v1/gateways.yaml
+++ b/hub/resourceeditors/gateway.networking.k8s.io/v1/gateways.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gateway.networking.k8s.io/v1/grpcroutes.yaml
+++ b/hub/resourceeditors/gateway.networking.k8s.io/v1/grpcroutes.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gateway.networking.k8s.io/v1/httproutes.yaml
+++ b/hub/resourceeditors/gateway.networking.k8s.io/v1/httproutes.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gateway.networking.k8s.io/v1alpha2/backendlbpolicies.yaml
+++ b/hub/resourceeditors/gateway.networking.k8s.io/v1alpha2/backendlbpolicies.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gateway.networking.k8s.io/v1alpha2/backendtlspolicies.yaml
+++ b/hub/resourceeditors/gateway.networking.k8s.io/v1alpha2/backendtlspolicies.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gateway.networking.k8s.io/v1alpha2/grpcroutes.yaml
+++ b/hub/resourceeditors/gateway.networking.k8s.io/v1alpha2/grpcroutes.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gateway.networking.k8s.io/v1alpha2/tcproutes.yaml
+++ b/hub/resourceeditors/gateway.networking.k8s.io/v1alpha2/tcproutes.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gateway.networking.k8s.io/v1alpha2/tlsroutes.yaml
+++ b/hub/resourceeditors/gateway.networking.k8s.io/v1alpha2/tlsroutes.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gateway.networking.k8s.io/v1alpha2/udproutes.yaml
+++ b/hub/resourceeditors/gateway.networking.k8s.io/v1alpha2/udproutes.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gateway.networking.k8s.io/v1alpha3/backendtlspolicies.yaml
+++ b/hub/resourceeditors/gateway.networking.k8s.io/v1alpha3/backendtlspolicies.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gateway.networking.k8s.io/v1alpha3/tlsroutes.yaml
+++ b/hub/resourceeditors/gateway.networking.k8s.io/v1alpha3/tlsroutes.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gateway.networking.k8s.io/v1beta1/gatewayclasses.yaml
+++ b/hub/resourceeditors/gateway.networking.k8s.io/v1beta1/gatewayclasses.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gateway.networking.k8s.io/v1beta1/gateways.yaml
+++ b/hub/resourceeditors/gateway.networking.k8s.io/v1beta1/gateways.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gateway.networking.k8s.io/v1beta1/httproutes.yaml
+++ b/hub/resourceeditors/gateway.networking.k8s.io/v1beta1/httproutes.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gateway.networking.k8s.io/v1beta1/referencegrants.yaml
+++ b/hub/resourceeditors/gateway.networking.k8s.io/v1beta1/referencegrants.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gateway.networking.x-k8s.io/v1alpha1/xbackendtrafficpolicies.yaml
+++ b/hub/resourceeditors/gateway.networking.x-k8s.io/v1alpha1/xbackendtrafficpolicies.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gateway.networking.x-k8s.io/v1alpha1/xlistenersets.yaml
+++ b/hub/resourceeditors/gateway.networking.x-k8s.io/v1alpha1/xlistenersets.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gateway.networking.x-k8s.io/v1alpha1/xmeshes.yaml
+++ b/hub/resourceeditors/gateway.networking.x-k8s.io/v1alpha1/xmeshes.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gateway.open-cluster-management.io/v1alpha1/clustergateways.yaml
+++ b/hub/resourceeditors/gateway.open-cluster-management.io/v1alpha1/clustergateways.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gateway.voyagermesh.com/v1alpha1/kafkaroutes.yaml
+++ b/hub/resourceeditors/gateway.voyagermesh.com/v1alpha1/kafkaroutes.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gateway.voyagermesh.com/v1alpha1/mongodbroutes.yaml
+++ b/hub/resourceeditors/gateway.voyagermesh.com/v1alpha1/mongodbroutes.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gateway.voyagermesh.com/v1alpha1/mssqlserverroutes.yaml
+++ b/hub/resourceeditors/gateway.voyagermesh.com/v1alpha1/mssqlserverroutes.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gateway.voyagermesh.com/v1alpha1/mysqlroutes.yaml
+++ b/hub/resourceeditors/gateway.voyagermesh.com/v1alpha1/mysqlroutes.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gateway.voyagermesh.com/v1alpha1/oracleroutes.yaml
+++ b/hub/resourceeditors/gateway.voyagermesh.com/v1alpha1/oracleroutes.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gateway.voyagermesh.com/v1alpha1/postgresroutes.yaml
+++ b/hub/resourceeditors/gateway.voyagermesh.com/v1alpha1/postgresroutes.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gateway.voyagermesh.com/v1alpha1/redisroutes.yaml
+++ b/hub/resourceeditors/gateway.voyagermesh.com/v1alpha1/redisroutes.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gcp.kubedb.com/v1alpha1/storeconfigs.yaml
+++ b/hub/resourceeditors/gcp.kubedb.com/v1alpha1/storeconfigs.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gcp.kubedb.com/v1beta1/providerconfigs.yaml
+++ b/hub/resourceeditors/gcp.kubedb.com/v1beta1/providerconfigs.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gcp.kubedb.com/v1beta1/providerconfigusages.yaml
+++ b/hub/resourceeditors/gcp.kubedb.com/v1beta1/providerconfigusages.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gitops.kubedb.com/v1alpha1/cassandras.yaml
+++ b/hub/resourceeditors/gitops.kubedb.com/v1alpha1/cassandras.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gitops.kubedb.com/v1alpha1/clickhouses.yaml
+++ b/hub/resourceeditors/gitops.kubedb.com/v1alpha1/clickhouses.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gitops.kubedb.com/v1alpha1/druids.yaml
+++ b/hub/resourceeditors/gitops.kubedb.com/v1alpha1/druids.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gitops.kubedb.com/v1alpha1/elasticsearches.yaml
+++ b/hub/resourceeditors/gitops.kubedb.com/v1alpha1/elasticsearches.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gitops.kubedb.com/v1alpha1/hanadbs.yaml
+++ b/hub/resourceeditors/gitops.kubedb.com/v1alpha1/hanadbs.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gitops.kubedb.com/v1alpha1/hazelcasts.yaml
+++ b/hub/resourceeditors/gitops.kubedb.com/v1alpha1/hazelcasts.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gitops.kubedb.com/v1alpha1/ignites.yaml
+++ b/hub/resourceeditors/gitops.kubedb.com/v1alpha1/ignites.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gitops.kubedb.com/v1alpha1/kafkas.yaml
+++ b/hub/resourceeditors/gitops.kubedb.com/v1alpha1/kafkas.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gitops.kubedb.com/v1alpha1/mariadbs.yaml
+++ b/hub/resourceeditors/gitops.kubedb.com/v1alpha1/mariadbs.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gitops.kubedb.com/v1alpha1/memcacheds.yaml
+++ b/hub/resourceeditors/gitops.kubedb.com/v1alpha1/memcacheds.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gitops.kubedb.com/v1alpha1/milvuses.yaml
+++ b/hub/resourceeditors/gitops.kubedb.com/v1alpha1/milvuses.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gitops.kubedb.com/v1alpha1/mongodbs.yaml
+++ b/hub/resourceeditors/gitops.kubedb.com/v1alpha1/mongodbs.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gitops.kubedb.com/v1alpha1/mssqlservers.yaml
+++ b/hub/resourceeditors/gitops.kubedb.com/v1alpha1/mssqlservers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gitops.kubedb.com/v1alpha1/mysqls.yaml
+++ b/hub/resourceeditors/gitops.kubedb.com/v1alpha1/mysqls.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gitops.kubedb.com/v1alpha1/neo4js.yaml
+++ b/hub/resourceeditors/gitops.kubedb.com/v1alpha1/neo4js.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gitops.kubedb.com/v1alpha1/oracles.yaml
+++ b/hub/resourceeditors/gitops.kubedb.com/v1alpha1/oracles.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gitops.kubedb.com/v1alpha1/perconaxtradbs.yaml
+++ b/hub/resourceeditors/gitops.kubedb.com/v1alpha1/perconaxtradbs.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gitops.kubedb.com/v1alpha1/pgbouncers.yaml
+++ b/hub/resourceeditors/gitops.kubedb.com/v1alpha1/pgbouncers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gitops.kubedb.com/v1alpha1/pgpools.yaml
+++ b/hub/resourceeditors/gitops.kubedb.com/v1alpha1/pgpools.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gitops.kubedb.com/v1alpha1/postgreses.yaml
+++ b/hub/resourceeditors/gitops.kubedb.com/v1alpha1/postgreses.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gitops.kubedb.com/v1alpha1/proxysqls.yaml
+++ b/hub/resourceeditors/gitops.kubedb.com/v1alpha1/proxysqls.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gitops.kubedb.com/v1alpha1/qdrants.yaml
+++ b/hub/resourceeditors/gitops.kubedb.com/v1alpha1/qdrants.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gitops.kubedb.com/v1alpha1/rabbitmqs.yaml
+++ b/hub/resourceeditors/gitops.kubedb.com/v1alpha1/rabbitmqs.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gitops.kubedb.com/v1alpha1/redises.yaml
+++ b/hub/resourceeditors/gitops.kubedb.com/v1alpha1/redises.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gitops.kubedb.com/v1alpha1/redissentinels.yaml
+++ b/hub/resourceeditors/gitops.kubedb.com/v1alpha1/redissentinels.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gitops.kubedb.com/v1alpha1/singlestores.yaml
+++ b/hub/resourceeditors/gitops.kubedb.com/v1alpha1/singlestores.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gitops.kubedb.com/v1alpha1/solrs.yaml
+++ b/hub/resourceeditors/gitops.kubedb.com/v1alpha1/solrs.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gitops.kubedb.com/v1alpha1/weaviates.yaml
+++ b/hub/resourceeditors/gitops.kubedb.com/v1alpha1/weaviates.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/gitops.kubedb.com/v1alpha1/zookeepers.yaml
+++ b/hub/resourceeditors/gitops.kubedb.com/v1alpha1/zookeepers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/helm.toolkit.fluxcd.io/v2/helmreleases.yaml
+++ b/hub/resourceeditors/helm.toolkit.fluxcd.io/v2/helmreleases.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/helm.toolkit.fluxcd.io/v2beta1/helmreleases.yaml
+++ b/hub/resourceeditors/helm.toolkit.fluxcd.io/v2beta1/helmreleases.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/helm.toolkit.fluxcd.io/v2beta2/helmreleases.yaml
+++ b/hub/resourceeditors/helm.toolkit.fluxcd.io/v2beta2/helmreleases.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/iam.aws.kubedb.com/v1alpha1/roles.yaml
+++ b/hub/resourceeditors/iam.aws.kubedb.com/v1alpha1/roles.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/identity.k8s.appscode.com/v1alpha1/clusteridentitys.yaml
+++ b/hub/resourceeditors/identity.k8s.appscode.com/v1alpha1/clusteridentitys.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/identity.k8s.appscode.com/v1alpha1/selfsubjectnamespaceaccessreviews.yaml
+++ b/hub/resourceeditors/identity.k8s.appscode.com/v1alpha1/selfsubjectnamespaceaccessreviews.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/identity.k8s.appscode.com/v1alpha1/siteinfos.yaml
+++ b/hub/resourceeditors/identity.k8s.appscode.com/v1alpha1/siteinfos.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta1/imagepolicies.yaml
+++ b/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta1/imagepolicies.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta1/imagerepositories.yaml
+++ b/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta1/imagerepositories.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta1/imageupdateautomations.yaml
+++ b/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta1/imageupdateautomations.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta2/imagepolicies.yaml
+++ b/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta2/imagepolicies.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta2/imagerepositories.yaml
+++ b/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta2/imagerepositories.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta2/imageupdateautomations.yaml
+++ b/hub/resourceeditors/image.toolkit.fluxcd.io/v1beta2/imageupdateautomations.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/imagepolicy.k8s.io/v1alpha1/imagereviews.yaml
+++ b/hub/resourceeditors/imagepolicy.k8s.io/v1alpha1/imagereviews.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha1/azureasomanagedclusters.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha1/azureasomanagedclusters.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha1/azureasomanagedclustertemplates.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha1/azureasomanagedclustertemplates.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha1/azureasomanagedcontrolplanes.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha1/azureasomanagedcontrolplanes.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha1/azureasomanagedcontrolplanetemplates.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha1/azureasomanagedcontrolplanetemplates.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha1/azureasomanagedmachinepools.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha1/azureasomanagedmachinepools.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha1/azureasomanagedmachinepooltemplates.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha1/azureasomanagedmachinepooltemplates.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha3/azureserviceprincipals.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha3/azureserviceprincipals.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha3/azuresystemassignedidentites.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha3/azuresystemassignedidentites.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha3/azureuserassignedidentites.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1alpha3/azureuserassignedidentites.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azureclusteridentities.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azureclusteridentities.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azureclusters.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azureclusters.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azureclustertemplates.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azureclustertemplates.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremachinepoolmachines.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremachinepoolmachines.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremachinepools.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremachinepools.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremachines.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremachines.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremachinetemplates.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremachinetemplates.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedclusters.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedclusters.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedclustertemplates.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedclustertemplates.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedcontrolplanes.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedcontrolplanes.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedcontrolplanetemplates.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedcontrolplanetemplates.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedmachinepools.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedmachinepools.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedmachinepooltemplates.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/azuremanagedmachinepooltemplates.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpclusters.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpclusters.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpclustertemplates.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpclustertemplates.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpmachines.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpmachines.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpmachinetemplates.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpmachinetemplates.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpmanagedclusters.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpmanagedclusters.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpmanagedcontrolplanes.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpmanagedcontrolplanes.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpmanagedmachinepools.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta1/gcpmanagedmachinepools.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclustercontrolleridentities.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclustercontrolleridentities.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclusterroleidentities.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclusterroleidentities.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclusters.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclusters.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclusterstaticidentities.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclusterstaticidentities.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclustertemplates.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsclustertemplates.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsfargateprofiles.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsfargateprofiles.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmachinepools.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmachinepools.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmachines.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmachines.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmachinetemplates.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmachinetemplates.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmanagedclusters.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmanagedclusters.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmanagedmachinepools.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/awsmanagedmachinepools.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/rosaclusters.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/rosaclusters.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/rosamachinepools.yaml
+++ b/hub/resourceeditors/infrastructure.cluster.x-k8s.io/v1beta2/rosamachinepools.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/internal.apiserver.k8s.io/v1alpha1/storageversions.yaml
+++ b/hub/resourceeditors/internal.apiserver.k8s.io/v1alpha1/storageversions.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ipam.cluster.x-k8s.io/v1alpha1/ipaddressclaims.yaml
+++ b/hub/resourceeditors/ipam.cluster.x-k8s.io/v1alpha1/ipaddressclaims.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ipam.cluster.x-k8s.io/v1alpha1/ipaddresses.yaml
+++ b/hub/resourceeditors/ipam.cluster.x-k8s.io/v1alpha1/ipaddresses.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ipam.cluster.x-k8s.io/v1beta1/ipaddressclaims.yaml
+++ b/hub/resourceeditors/ipam.cluster.x-k8s.io/v1beta1/ipaddressclaims.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ipam.cluster.x-k8s.io/v1beta1/ipaddresses.yaml
+++ b/hub/resourceeditors/ipam.cluster.x-k8s.io/v1beta1/ipaddresses.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/kafka.aws.kubedb.com/v1alpha1/clusters.yaml
+++ b/hub/resourceeditors/kafka.aws.kubedb.com/v1alpha1/clusters.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/kafka.aws.kubedb.com/v1alpha1/configurations.yaml
+++ b/hub/resourceeditors/kafka.aws.kubedb.com/v1alpha1/configurations.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/kafka.kubedb.com/v1alpha1/connectclusters.yaml
+++ b/hub/resourceeditors/kafka.kubedb.com/v1alpha1/connectclusters.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/kafka.kubedb.com/v1alpha1/connectors.yaml
+++ b/hub/resourceeditors/kafka.kubedb.com/v1alpha1/connectors.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/kafka.kubedb.com/v1alpha1/restproxies.yaml
+++ b/hub/resourceeditors/kafka.kubedb.com/v1alpha1/restproxies.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/kafka.kubedb.com/v1alpha1/schemaregistries.yaml
+++ b/hub/resourceeditors/kafka.kubedb.com/v1alpha1/schemaregistries.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/karpenter.azure.com/v1alpha2/aksnodeclasses.yaml
+++ b/hub/resourceeditors/karpenter.azure.com/v1alpha2/aksnodeclasses.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/karpenter.k8s.aws/v1beta1/ec2nodeclasses.yaml
+++ b/hub/resourceeditors/karpenter.k8s.aws/v1beta1/ec2nodeclasses.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/karpenter.sh/v1beta1/nodeclaims.yaml
+++ b/hub/resourceeditors/karpenter.sh/v1beta1/nodeclaims.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/karpenter.sh/v1beta1/nodepools.yaml
+++ b/hub/resourceeditors/karpenter.sh/v1beta1/nodepools.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/keyvault.azure.kubedb.com/v1alpha1/keys.yaml
+++ b/hub/resourceeditors/keyvault.azure.kubedb.com/v1alpha1/keys.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/keyvault.azure.kubedb.com/v1alpha1/vaults.yaml
+++ b/hub/resourceeditors/keyvault.azure.kubedb.com/v1alpha1/vaults.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/kinesis.aws.kubedb.com/v1alpha1/streams.yaml
+++ b/hub/resourceeditors/kinesis.aws.kubedb.com/v1alpha1/streams.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/kms.aws.kubedb.com/v1alpha1/keys.yaml
+++ b/hub/resourceeditors/kms.aws.kubedb.com/v1alpha1/keys.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/kube-bind.appscode.com/v1alpha1/apiservicebindings.yaml
+++ b/hub/resourceeditors/kube-bind.appscode.com/v1alpha1/apiservicebindings.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/kube-bind.appscode.com/v1alpha1/apiserviceexportrequests.yaml
+++ b/hub/resourceeditors/kube-bind.appscode.com/v1alpha1/apiserviceexportrequests.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/kube-bind.appscode.com/v1alpha1/apiserviceexports.yaml
+++ b/hub/resourceeditors/kube-bind.appscode.com/v1alpha1/apiserviceexports.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/kube-bind.appscode.com/v1alpha1/apiservicenamespaces.yaml
+++ b/hub/resourceeditors/kube-bind.appscode.com/v1alpha1/apiservicenamespaces.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/kube-bind.appscode.com/v1alpha1/clusterbindings.yaml
+++ b/hub/resourceeditors/kube-bind.appscode.com/v1alpha1/clusterbindings.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/kubedb.com/v1/elasticsearches.yaml
+++ b/hub/resourceeditors/kubedb.com/v1/elasticsearches.yaml
@@ -27,7 +27,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -42,7 +42,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -57,7 +57,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -74,7 +74,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -89,7 +89,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -104,7 +104,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -133,7 +133,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -148,7 +148,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -163,7 +163,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -180,7 +180,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -195,7 +195,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -214,7 +214,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -229,7 +229,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -246,7 +246,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -262,7 +262,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: true
     options:
@@ -270,7 +270,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kubedb.com/v1/kafkas.yaml
+++ b/hub/resourceeditors/kubedb.com/v1/kafkas.yaml
@@ -27,7 +27,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -42,7 +42,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -57,7 +57,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -86,7 +86,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -101,7 +101,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -116,7 +116,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -133,7 +133,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -148,7 +148,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -165,7 +165,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -180,7 +180,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -197,7 +197,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -213,7 +213,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: true
     options:
@@ -221,7 +221,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kubedb.com/v1/mariadbs.yaml
+++ b/hub/resourceeditors/kubedb.com/v1/mariadbs.yaml
@@ -27,7 +27,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -42,7 +42,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -57,7 +57,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -74,7 +74,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -89,7 +89,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -104,7 +104,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -133,7 +133,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -148,7 +148,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -163,7 +163,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -180,7 +180,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -195,7 +195,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -212,7 +212,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -227,7 +227,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -244,7 +244,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -260,7 +260,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: true
     options:
@@ -268,7 +268,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kubedb.com/v1/memcacheds.yaml
+++ b/hub/resourceeditors/kubedb.com/v1/memcacheds.yaml
@@ -27,7 +27,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -42,7 +42,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -57,7 +57,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -81,7 +81,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -96,7 +96,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -113,7 +113,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -130,7 +130,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -145,7 +145,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -161,7 +161,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false
     options:
@@ -169,7 +169,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kubedb.com/v1/mongodbs.yaml
+++ b/hub/resourceeditors/kubedb.com/v1/mongodbs.yaml
@@ -27,7 +27,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -42,7 +42,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -57,7 +57,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -74,7 +74,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -89,7 +89,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -104,7 +104,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -133,7 +133,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -148,7 +148,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -163,7 +163,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -180,7 +180,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -195,7 +195,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -212,7 +212,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -227,7 +227,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -244,7 +244,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -260,7 +260,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: true
     options:
@@ -268,7 +268,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kubedb.com/v1/mysqls.yaml
+++ b/hub/resourceeditors/kubedb.com/v1/mysqls.yaml
@@ -27,7 +27,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -42,7 +42,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -57,7 +57,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -74,7 +74,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -89,7 +89,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -104,7 +104,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -133,7 +133,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -148,7 +148,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -163,7 +163,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -180,7 +180,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -195,7 +195,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -212,7 +212,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -227,7 +227,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -244,7 +244,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -260,7 +260,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: true
     options:
@@ -268,7 +268,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kubedb.com/v1/perconaxtradbs.yaml
+++ b/hub/resourceeditors/kubedb.com/v1/perconaxtradbs.yaml
@@ -27,7 +27,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -42,7 +42,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -71,7 +71,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -86,7 +86,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -101,7 +101,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -118,7 +118,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -133,7 +133,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -150,7 +150,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -165,7 +165,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -181,7 +181,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: true
     options:
@@ -189,7 +189,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kubedb.com/v1/pgbouncers.yaml
+++ b/hub/resourceeditors/kubedb.com/v1/pgbouncers.yaml
@@ -27,7 +27,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -42,7 +42,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -66,7 +66,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -81,7 +81,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -98,7 +98,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -115,7 +115,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -131,7 +131,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false
     options:
@@ -139,7 +139,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kubedb.com/v1/postgreses.yaml
+++ b/hub/resourceeditors/kubedb.com/v1/postgreses.yaml
@@ -27,7 +27,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -42,7 +42,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -57,7 +57,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -74,7 +74,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -89,7 +89,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -104,7 +104,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -133,7 +133,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -148,7 +148,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -163,7 +163,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -180,7 +180,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -195,7 +195,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -212,7 +212,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -227,7 +227,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -244,7 +244,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -260,7 +260,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: true
     options:
@@ -268,7 +268,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kubedb.com/v1/proxysqls.yaml
+++ b/hub/resourceeditors/kubedb.com/v1/proxysqls.yaml
@@ -27,7 +27,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -42,7 +42,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -57,7 +57,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -79,7 +79,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -94,7 +94,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -111,7 +111,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -128,7 +128,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -143,7 +143,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -159,7 +159,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false
     options:
@@ -167,7 +167,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kubedb.com/v1/redises.yaml
+++ b/hub/resourceeditors/kubedb.com/v1/redises.yaml
@@ -27,7 +27,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -42,7 +42,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -57,7 +57,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -74,7 +74,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -89,7 +89,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -104,7 +104,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -133,7 +133,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -148,7 +148,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -163,7 +163,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -180,7 +180,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -195,7 +195,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -212,7 +212,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -227,7 +227,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -244,7 +244,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -260,7 +260,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: true
     options:
@@ -268,7 +268,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kubedb.com/v1/redissentinels.yaml
+++ b/hub/resourceeditors/kubedb.com/v1/redissentinels.yaml
@@ -27,7 +27,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -42,7 +42,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -57,7 +57,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -79,7 +79,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -94,7 +94,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -111,7 +111,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -128,7 +128,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -143,7 +143,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -159,7 +159,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false
   variants:

--- a/hub/resourceeditors/kubedb.com/v1alpha2/aerospikes.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/aerospikes.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/kubedb.com/v1alpha2/cassandras.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/cassandras.yaml
@@ -27,7 +27,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -42,7 +42,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -57,7 +57,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -74,7 +74,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -89,7 +89,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -104,7 +104,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -133,7 +133,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -148,7 +148,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -163,7 +163,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -180,7 +180,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -195,7 +195,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -212,7 +212,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -227,7 +227,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -244,7 +244,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -260,7 +260,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: true
     options:
@@ -268,7 +268,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kubedb.com/v1alpha2/clickhouses.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/clickhouses.yaml
@@ -27,7 +27,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -42,7 +42,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -57,7 +57,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -74,7 +74,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -89,7 +89,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -104,7 +104,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -133,7 +133,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -148,7 +148,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -163,7 +163,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -180,7 +180,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -195,7 +195,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -212,7 +212,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -227,7 +227,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -244,7 +244,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -260,7 +260,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: true
     options:
@@ -268,7 +268,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kubedb.com/v1alpha2/db2s.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/db2s.yaml
@@ -25,7 +25,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: true
     options:
@@ -33,7 +33,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kubedb.com/v1alpha2/documentdbs.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/documentdbs.yaml
@@ -27,7 +27,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -42,7 +42,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -57,7 +57,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -86,7 +86,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -101,7 +101,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -116,7 +116,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -133,7 +133,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -148,7 +148,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -165,7 +165,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -180,7 +180,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -196,7 +196,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: true
     options:
@@ -204,7 +204,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kubedb.com/v1alpha2/druids.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/druids.yaml
@@ -27,7 +27,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -42,7 +42,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -57,7 +57,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -74,7 +74,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -89,7 +89,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -104,7 +104,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -133,7 +133,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -148,7 +148,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -163,7 +163,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -180,7 +180,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -195,7 +195,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -212,7 +212,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -227,7 +227,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -244,7 +244,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -260,7 +260,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: true
     options:
@@ -268,7 +268,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kubedb.com/v1alpha2/elasticsearches.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/elasticsearches.yaml
@@ -27,7 +27,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -42,7 +42,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -59,7 +59,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -74,7 +74,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -101,7 +101,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -116,7 +116,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -131,7 +131,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -150,7 +150,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -165,7 +165,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -181,7 +181,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: true
     options:
@@ -189,7 +189,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kubedb.com/v1alpha2/etcds.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/etcds.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/kubedb.com/v1alpha2/hanadbs.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/hanadbs.yaml
@@ -27,7 +27,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -42,7 +42,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -64,7 +64,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -81,7 +81,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -98,7 +98,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -113,7 +113,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -129,7 +129,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: true
     options:
@@ -137,7 +137,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kubedb.com/v1alpha2/hazelcasts.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/hazelcasts.yaml
@@ -27,7 +27,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -42,7 +42,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -57,7 +57,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -86,7 +86,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -101,7 +101,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -116,7 +116,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -133,7 +133,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -148,7 +148,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -165,7 +165,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -180,7 +180,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -197,7 +197,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -213,7 +213,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: true
     options:
@@ -221,7 +221,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kubedb.com/v1alpha2/ignites.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/ignites.yaml
@@ -27,7 +27,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -42,7 +42,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -57,7 +57,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -86,7 +86,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -101,7 +101,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -116,7 +116,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -133,7 +133,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -148,7 +148,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -165,7 +165,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -180,7 +180,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -196,7 +196,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: true
     options:
@@ -204,7 +204,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kubedb.com/v1alpha2/kafkas.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/kafkas.yaml
@@ -27,7 +27,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -43,7 +43,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: true
     options:
@@ -51,7 +51,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kubedb.com/v1alpha2/mariadbs.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/mariadbs.yaml
@@ -27,7 +27,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -42,7 +42,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -59,7 +59,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -74,7 +74,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -89,7 +89,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -118,7 +118,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -133,7 +133,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -148,7 +148,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -165,7 +165,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -180,7 +180,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -196,7 +196,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: true
     options:
@@ -204,7 +204,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kubedb.com/v1alpha2/memcacheds.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/memcacheds.yaml
@@ -27,7 +27,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -42,7 +42,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -66,7 +66,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -81,7 +81,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -98,7 +98,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -113,7 +113,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -129,7 +129,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false
     options:
@@ -137,7 +137,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kubedb.com/v1alpha2/milvuses.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/milvuses.yaml
@@ -27,7 +27,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -42,7 +42,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -57,7 +57,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -86,7 +86,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -101,7 +101,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -116,7 +116,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -133,7 +133,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -148,7 +148,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -165,7 +165,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -180,7 +180,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -196,7 +196,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: true
     options:
@@ -204,7 +204,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kubedb.com/v1alpha2/mongodbs.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/mongodbs.yaml
@@ -27,7 +27,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -42,7 +42,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -59,7 +59,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -74,7 +74,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -89,7 +89,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -118,7 +118,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -133,7 +133,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -148,7 +148,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -165,7 +165,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -179,7 +179,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -195,7 +195,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -210,7 +210,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -226,7 +226,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: true
     options:
@@ -234,7 +234,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kubedb.com/v1alpha2/mssqlservers.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/mssqlservers.yaml
@@ -27,7 +27,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -42,7 +42,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -57,7 +57,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -74,7 +74,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -89,7 +89,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -104,7 +104,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -133,7 +133,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -148,7 +148,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -163,7 +163,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -180,7 +180,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -195,7 +195,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -212,7 +212,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -227,7 +227,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -244,7 +244,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -260,7 +260,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: true
     options:
@@ -268,7 +268,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kubedb.com/v1alpha2/mysqls.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/mysqls.yaml
@@ -27,7 +27,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -42,7 +42,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -59,7 +59,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -74,7 +74,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -89,7 +89,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -118,7 +118,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -133,7 +133,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -148,7 +148,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -165,7 +165,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -180,7 +180,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -196,7 +196,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: true
     options:
@@ -204,7 +204,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kubedb.com/v1alpha2/neo4js.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/neo4js.yaml
@@ -27,7 +27,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -42,7 +42,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -57,7 +57,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -74,7 +74,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -89,7 +89,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -104,7 +104,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -133,7 +133,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -148,7 +148,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -163,7 +163,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -180,7 +180,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -195,7 +195,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -212,7 +212,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -227,7 +227,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -243,7 +243,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: true
     options:
@@ -251,7 +251,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kubedb.com/v1alpha2/oracles.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/oracles.yaml
@@ -27,7 +27,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -42,7 +42,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -69,7 +69,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -84,7 +84,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -101,7 +101,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -116,7 +116,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -133,7 +133,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -150,7 +150,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -166,7 +166,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: true
     options:
@@ -174,7 +174,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kubedb.com/v1alpha2/perconaxtradbs.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/perconaxtradbs.yaml
@@ -25,7 +25,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: true
     options:
@@ -33,7 +33,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kubedb.com/v1alpha2/pgbouncers.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/pgbouncers.yaml
@@ -25,7 +25,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false
     options:
@@ -33,7 +33,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kubedb.com/v1alpha2/pgpools.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/pgpools.yaml
@@ -27,7 +27,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -42,7 +42,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -57,7 +57,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -81,7 +81,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -96,7 +96,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -113,7 +113,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -130,7 +130,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -145,7 +145,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -161,7 +161,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: true
     options:
@@ -169,7 +169,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kubedb.com/v1alpha2/postgreses.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/postgreses.yaml
@@ -27,7 +27,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -42,7 +42,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -59,7 +59,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -74,7 +74,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -89,7 +89,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -118,7 +118,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -133,7 +133,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -148,7 +148,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -165,7 +165,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -180,7 +180,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -196,7 +196,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: true
     options:
@@ -204,7 +204,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kubedb.com/v1alpha2/proxysqls.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/proxysqls.yaml
@@ -27,7 +27,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -42,7 +42,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -57,7 +57,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -79,7 +79,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -94,7 +94,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -111,7 +111,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -126,7 +126,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -142,7 +142,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false
     options:
@@ -150,7 +150,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kubedb.com/v1alpha2/qdrants.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/qdrants.yaml
@@ -27,7 +27,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -42,7 +42,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -57,7 +57,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -86,7 +86,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -101,7 +101,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -116,7 +116,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -133,7 +133,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -148,7 +148,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -165,7 +165,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -180,7 +180,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -196,7 +196,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: true
     options:
@@ -204,7 +204,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kubedb.com/v1alpha2/rabbitmqs.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/rabbitmqs.yaml
@@ -27,7 +27,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -42,7 +42,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -57,7 +57,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -86,7 +86,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -101,7 +101,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -116,7 +116,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -133,7 +133,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -148,7 +148,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -165,7 +165,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -180,7 +180,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -197,7 +197,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -213,7 +213,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: true
     options:
@@ -221,7 +221,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kubedb.com/v1alpha2/redises.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/redises.yaml
@@ -27,7 +27,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -42,7 +42,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -59,7 +59,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -74,7 +74,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -89,7 +89,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -118,7 +118,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -133,7 +133,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -148,7 +148,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -165,7 +165,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -180,7 +180,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -196,7 +196,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: true
     options:
@@ -204,7 +204,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kubedb.com/v1alpha2/redissentinels.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/redissentinels.yaml
@@ -25,7 +25,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false
   variants:

--- a/hub/resourceeditors/kubedb.com/v1alpha2/singlestores.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/singlestores.yaml
@@ -27,7 +27,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -42,7 +42,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -57,7 +57,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -74,7 +74,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -89,7 +89,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -104,7 +104,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -133,7 +133,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -148,7 +148,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -163,7 +163,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -180,7 +180,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -195,7 +195,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -212,7 +212,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -227,7 +227,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -244,7 +244,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -260,7 +260,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: true
     options:
@@ -268,7 +268,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kubedb.com/v1alpha2/solrs.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/solrs.yaml
@@ -27,7 +27,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -42,7 +42,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -57,7 +57,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -74,7 +74,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -89,7 +89,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -104,7 +104,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -133,7 +133,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -148,7 +148,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -163,7 +163,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -180,7 +180,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -195,7 +195,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -212,7 +212,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -227,7 +227,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -244,7 +244,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -260,7 +260,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: true
     options:
@@ -268,7 +268,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kubedb.com/v1alpha2/weaviates.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/weaviates.yaml
@@ -27,7 +27,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -42,7 +42,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -57,7 +57,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -86,7 +86,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -101,7 +101,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -116,7 +116,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -133,7 +133,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -148,7 +148,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -164,7 +164,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: true
     options:
@@ -172,7 +172,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kubedb.com/v1alpha2/zookeepers.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/zookeepers.yaml
@@ -27,7 +27,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -42,7 +42,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -57,7 +57,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -74,7 +74,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -89,7 +89,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -104,7 +104,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -133,7 +133,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -148,7 +148,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -163,7 +163,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-create
@@ -180,7 +180,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: true
         flow: standalone-edit
@@ -197,7 +197,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-create
@@ -212,7 +212,7 @@ spec:
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io
             kind: HelmRepository
-            name: appscode-charts-oci
+            name: appscode-wizards-oci
           version: v0.35.0
         enforceQuota: false
         flow: standalone-edit
@@ -228,7 +228,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: true
     options:
@@ -236,7 +236,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kubevault.com/v1alpha2/vaultservers.yaml
+++ b/hub/resourceeditors/kubevault.com/v1alpha2/vaultservers.yaml
@@ -25,7 +25,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false
     options:
@@ -33,7 +33,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
   variants:
   - name: default

--- a/hub/resourceeditors/kustomize.toolkit.fluxcd.io/v1/kustomizations.yaml
+++ b/hub/resourceeditors/kustomize.toolkit.fluxcd.io/v1/kustomizations.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/kustomize.toolkit.fluxcd.io/v1beta2/kustomizations.yaml
+++ b/hub/resourceeditors/kustomize.toolkit.fluxcd.io/v1beta2/kustomizations.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/management.k8s.appscode.com/v1alpha1/projectquotas.yaml
+++ b/hub/resourceeditors/management.k8s.appscode.com/v1alpha1/projectquotas.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/match.gatekeeper.sh/match/matchcrd.yaml
+++ b/hub/resourceeditors/match.gatekeeper.sh/match/matchcrd.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/memorydb.aws.kubedb.com/v1alpha1/acls.yaml
+++ b/hub/resourceeditors/memorydb.aws.kubedb.com/v1alpha1/acls.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/memorydb.aws.kubedb.com/v1alpha1/clusters.yaml
+++ b/hub/resourceeditors/memorydb.aws.kubedb.com/v1alpha1/clusters.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/memorydb.aws.kubedb.com/v1alpha1/parametergroups.yaml
+++ b/hub/resourceeditors/memorydb.aws.kubedb.com/v1alpha1/parametergroups.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/memorydb.aws.kubedb.com/v1alpha1/snapshots.yaml
+++ b/hub/resourceeditors/memorydb.aws.kubedb.com/v1alpha1/snapshots.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/memorydb.aws.kubedb.com/v1alpha1/subnetgroups.yaml
+++ b/hub/resourceeditors/memorydb.aws.kubedb.com/v1alpha1/subnetgroups.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/meta.appscode.com/v1alpha1/resourcedescriptors.yaml
+++ b/hub/resourceeditors/meta.appscode.com/v1alpha1/resourcedescriptors.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/clusterprofiles.yaml
+++ b/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/clusterprofiles.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/gatewayinfoes.yaml
+++ b/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/gatewayinfoes.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/menuoutlines.yaml
+++ b/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/menuoutlines.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/menus.yaml
+++ b/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/menus.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourceblockdefinitions.yaml
+++ b/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourceblockdefinitions.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcecalculators.yaml
+++ b/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcecalculators.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcedescriptors.yaml
+++ b/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcedescriptors.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourceeditors.yaml
+++ b/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourceeditors.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcelayouts.yaml
+++ b/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcelayouts.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcemanifests.yaml
+++ b/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcemanifests.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourceoutlinefilters.yaml
+++ b/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourceoutlinefilters.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourceoutlines.yaml
+++ b/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourceoutlines.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcetabledefinitions.yaml
+++ b/hub/resourceeditors/meta.k8s.appscode.com/v1alpha1/resourcetabledefinitions.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/metrics.appscode.com/v1alpha1/metricsconfigurations.yaml
+++ b/hub/resourceeditors/metrics.appscode.com/v1alpha1/metricsconfigurations.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/migrator.kubedb.com/v1alpha1/migrators.yaml
+++ b/hub/resourceeditors/migrator.kubedb.com/v1alpha1/migrators.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/monitoring.coreos.com/v1/alertmanagers.yaml
+++ b/hub/resourceeditors/monitoring.coreos.com/v1/alertmanagers.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/monitoring.coreos.com/v1/podmonitors.yaml
+++ b/hub/resourceeditors/monitoring.coreos.com/v1/podmonitors.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/monitoring.coreos.com/v1/probes.yaml
+++ b/hub/resourceeditors/monitoring.coreos.com/v1/probes.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/monitoring.coreos.com/v1/prometheuses.yaml
+++ b/hub/resourceeditors/monitoring.coreos.com/v1/prometheuses.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/monitoring.coreos.com/v1/prometheusrules.yaml
+++ b/hub/resourceeditors/monitoring.coreos.com/v1/prometheusrules.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/monitoring.coreos.com/v1/servicemonitors.yaml
+++ b/hub/resourceeditors/monitoring.coreos.com/v1/servicemonitors.yaml
@@ -25,7 +25,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false
     instanceLabelPaths:

--- a/hub/resourceeditors/monitoring.coreos.com/v1/thanosrulers.yaml
+++ b/hub/resourceeditors/monitoring.coreos.com/v1/thanosrulers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/monitoring.coreos.com/v1alpha1/alertmanagerconfigs.yaml
+++ b/hub/resourceeditors/monitoring.coreos.com/v1alpha1/alertmanagerconfigs.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/monitoring.coreos.com/v1alpha1/prometheusagents.yaml
+++ b/hub/resourceeditors/monitoring.coreos.com/v1alpha1/prometheusagents.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/monitoring.coreos.com/v1alpha1/scrapeconfigs.yaml
+++ b/hub/resourceeditors/monitoring.coreos.com/v1alpha1/scrapeconfigs.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/mutations.gatekeeper.sh/v1/assign.yaml
+++ b/hub/resourceeditors/mutations.gatekeeper.sh/v1/assign.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/mutations.gatekeeper.sh/v1/assignmetadata.yaml
+++ b/hub/resourceeditors/mutations.gatekeeper.sh/v1/assignmetadata.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/mutations.gatekeeper.sh/v1/modifyset.yaml
+++ b/hub/resourceeditors/mutations.gatekeeper.sh/v1/modifyset.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/mutations.gatekeeper.sh/v1alpha1/assignimage.yaml
+++ b/hub/resourceeditors/mutations.gatekeeper.sh/v1alpha1/assignimage.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/privatednszones.yaml
+++ b/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/privatednszones.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/privatednszonevirtualnetworklinks.yaml
+++ b/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/privatednszonevirtualnetworklinks.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/routetables.yaml
+++ b/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/routetables.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/securitygroups.yaml
+++ b/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/securitygroups.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/subnetnetworksecuritygroupassociations.yaml
+++ b/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/subnetnetworksecuritygroupassociations.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/subnetroutetableassociations.yaml
+++ b/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/subnetroutetableassociations.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/subnets.yaml
+++ b/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/subnets.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/virtualnetworkpeerings.yaml
+++ b/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/virtualnetworkpeerings.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/virtualnetworks.yaml
+++ b/hub/resourceeditors/network.azure.kubedb.com/v1alpha1/virtualnetworks.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/networking.k8s.io/v1/ingressclasses.yaml
+++ b/hub/resourceeditors/networking.k8s.io/v1/ingressclasses.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/networking.k8s.io/v1/ingresses.yaml
+++ b/hub/resourceeditors/networking.k8s.io/v1/ingresses.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/networking.k8s.io/v1/networkpolicies.yaml
+++ b/hub/resourceeditors/networking.k8s.io/v1/networkpolicies.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/networking.k8s.io/v1beta1/ingressclasses.yaml
+++ b/hub/resourceeditors/networking.k8s.io/v1beta1/ingressclasses.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/networking.k8s.io/v1beta1/ingresses.yaml
+++ b/hub/resourceeditors/networking.k8s.io/v1beta1/ingresses.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/node.k8s.appscode.com/v1alpha1/nodetopologies.yaml
+++ b/hub/resourceeditors/node.k8s.appscode.com/v1alpha1/nodetopologies.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/node.k8s.io/v1/runtimeclasses.yaml
+++ b/hub/resourceeditors/node.k8s.io/v1/runtimeclasses.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/node.k8s.io/v1beta1/runtimeclasses.yaml
+++ b/hub/resourceeditors/node.k8s.io/v1beta1/runtimeclasses.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/notification.toolkit.fluxcd.io/v1/receivers.yaml
+++ b/hub/resourceeditors/notification.toolkit.fluxcd.io/v1/receivers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta1/alerts.yaml
+++ b/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta1/alerts.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta1/providers.yaml
+++ b/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta1/providers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta1/receivers.yaml
+++ b/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta1/receivers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta3/alerts.yaml
+++ b/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta3/alerts.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta3/providers.yaml
+++ b/hub/resourceeditors/notification.toolkit.fluxcd.io/v1beta3/providers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/offline.licenses.appscode.com/v1alpha1/offlinelicenses.yaml
+++ b/hub/resourceeditors/offline.licenses.appscode.com/v1alpha1/offlinelicenses.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/openviz.dev/v1alpha1/grafanadashboards.yaml
+++ b/hub/resourceeditors/openviz.dev/v1alpha1/grafanadashboards.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/openviz.dev/v1alpha1/grafanadashboardtemplates.yaml
+++ b/hub/resourceeditors/openviz.dev/v1alpha1/grafanadashboardtemplates.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/openviz.dev/v1alpha1/grafanadatasources.yaml
+++ b/hub/resourceeditors/openviz.dev/v1alpha1/grafanadatasources.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/operator.k8s.appscode.com/v1alpha1/shardconfigurations.yaml
+++ b/hub/resourceeditors/operator.k8s.appscode.com/v1alpha1/shardconfigurations.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/operator.open-cluster-management.io/v1/clustermanagers.yaml
+++ b/hub/resourceeditors/operator.open-cluster-management.io/v1/clustermanagers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/operator.open-cluster-management.io/v1/klusterlets.yaml
+++ b/hub/resourceeditors/operator.open-cluster-management.io/v1/klusterlets.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/cassandraopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/cassandraopsrequests.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/clickhouseopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/clickhouseopsrequests.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/documentdbopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/documentdbopsrequests.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/druidopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/druidopsrequests.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/elasticsearchopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/elasticsearchopsrequests.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/etcdopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/etcdopsrequests.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/hanadbopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/hanadbopsrequests.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/hazelcastopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/hazelcastopsrequests.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/igniteopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/igniteopsrequests.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/kafkaopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/kafkaopsrequests.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/mariadbopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/mariadbopsrequests.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/memcachedopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/memcachedopsrequests.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/milvusopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/milvusopsrequests.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/mongodbopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/mongodbopsrequests.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/mssqlserveropsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/mssqlserveropsrequests.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/mysqlopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/mysqlopsrequests.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/neo4jopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/neo4jopsrequests.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/oracleopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/oracleopsrequests.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/perconaxtradbopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/perconaxtradbopsrequests.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/pgbounceropsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/pgbounceropsrequests.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/pgpoolopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/pgpoolopsrequests.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/postgresopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/postgresopsrequests.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/proxysqlopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/proxysqlopsrequests.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/qdrantopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/qdrantopsrequests.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/rabbitmqopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/rabbitmqopsrequests.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/redisopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/redisopsrequests.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/redissentinelopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/redissentinelopsrequests.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/singlestoreopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/singlestoreopsrequests.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/solropsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/solropsrequests.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/weaviateopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/weaviateopsrequests.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ops.kubedb.com/v1alpha1/zookeeperopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubedb.com/v1alpha1/zookeeperopsrequests.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ops.kubevault.com/v1alpha1/vaultopsrequests.yaml
+++ b/hub/resourceeditors/ops.kubevault.com/v1alpha1/vaultopsrequests.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/pkg.crossplane.io/v1/configurationrevisions.yaml
+++ b/hub/resourceeditors/pkg.crossplane.io/v1/configurationrevisions.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/pkg.crossplane.io/v1/configurations.yaml
+++ b/hub/resourceeditors/pkg.crossplane.io/v1/configurations.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/pkg.crossplane.io/v1/providerrevisions.yaml
+++ b/hub/resourceeditors/pkg.crossplane.io/v1/providerrevisions.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/pkg.crossplane.io/v1/providers.yaml
+++ b/hub/resourceeditors/pkg.crossplane.io/v1/providers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/pkg.crossplane.io/v1alpha1/controllerconfigs.yaml
+++ b/hub/resourceeditors/pkg.crossplane.io/v1alpha1/controllerconfigs.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/pkg.crossplane.io/v1beta1/locks.yaml
+++ b/hub/resourceeditors/pkg.crossplane.io/v1beta1/locks.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/policy.kubevault.com/v1alpha1/vaultpolicies.yaml
+++ b/hub/resourceeditors/policy.kubevault.com/v1alpha1/vaultpolicies.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/policy.kubevault.com/v1alpha1/vaultpolicybindings.yaml
+++ b/hub/resourceeditors/policy.kubevault.com/v1alpha1/vaultpolicybindings.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/policy/v1beta1/evictions.yaml
+++ b/hub/resourceeditors/policy/v1beta1/evictions.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/policy/v1beta1/poddisruptionbudgets.yaml
+++ b/hub/resourceeditors/policy/v1beta1/poddisruptionbudgets.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/policy/v1beta1/podsecuritypolicies.yaml
+++ b/hub/resourceeditors/policy/v1beta1/podsecuritypolicies.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/postgres.kubedb.com/v1alpha1/publishers.yaml
+++ b/hub/resourceeditors/postgres.kubedb.com/v1alpha1/publishers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/postgres.kubedb.com/v1alpha1/subscribers.yaml
+++ b/hub/resourceeditors/postgres.kubedb.com/v1alpha1/subscribers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/products.x-helm.dev/v1alpha1/plans.yaml
+++ b/hub/resourceeditors/products.x-helm.dev/v1alpha1/plans.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/products.x-helm.dev/v1alpha1/products.yaml
+++ b/hub/resourceeditors/products.x-helm.dev/v1alpha1/products.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/proxy.open-cluster-management.io/v1alpha1/managedproxyconfigurations.yaml
+++ b/hub/resourceeditors/proxy.open-cluster-management.io/v1alpha1/managedproxyconfigurations.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/proxy.open-cluster-management.io/v1alpha1/managedproxyserviceresolvers.yaml
+++ b/hub/resourceeditors/proxy.open-cluster-management.io/v1alpha1/managedproxyserviceresolvers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/rbac.authorization.k8s.io/v1/clusterrolebindings.yaml
+++ b/hub/resourceeditors/rbac.authorization.k8s.io/v1/clusterrolebindings.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/rbac.authorization.k8s.io/v1/clusterroles.yaml
+++ b/hub/resourceeditors/rbac.authorization.k8s.io/v1/clusterroles.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/rbac.authorization.k8s.io/v1/rolebindings.yaml
+++ b/hub/resourceeditors/rbac.authorization.k8s.io/v1/rolebindings.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/rbac.authorization.k8s.io/v1/roles.yaml
+++ b/hub/resourceeditors/rbac.authorization.k8s.io/v1/roles.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clusteractivitystreams.yaml
+++ b/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clusteractivitystreams.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clusterendpoints.yaml
+++ b/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clusterendpoints.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clusterinstances.yaml
+++ b/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clusterinstances.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clusterparametergroups.yaml
+++ b/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clusterparametergroups.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clusterroleassociations.yaml
+++ b/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clusterroleassociations.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clusters.yaml
+++ b/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clusters.yaml
@@ -20,7 +20,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false
   variants:

--- a/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clustersnapshots.yaml
+++ b/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/clustersnapshots.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/dbinstanceautomatedbackupsreplications.yaml
+++ b/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/dbinstanceautomatedbackupsreplications.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/dbsnapshotcopies.yaml
+++ b/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/dbsnapshotcopies.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/eventsubscriptions.yaml
+++ b/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/eventsubscriptions.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/globalclusters.yaml
+++ b/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/globalclusters.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/instanceroleassociations.yaml
+++ b/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/instanceroleassociations.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/instances.yaml
+++ b/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/instances.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/optiongroups.yaml
+++ b/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/optiongroups.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/parametergroups.yaml
+++ b/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/parametergroups.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/proxies.yaml
+++ b/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/proxies.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/proxydefaulttargetgroups.yaml
+++ b/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/proxydefaulttargetgroups.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/proxyendpoints.yaml
+++ b/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/proxyendpoints.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/proxytargets.yaml
+++ b/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/proxytargets.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/snapshots.yaml
+++ b/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/snapshots.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/subnetgroups.yaml
+++ b/hub/resourceeditors/rds.aws.kubedb.com/v1alpha1/subnetgroups.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/redis.gcp.kubedb.com/v1alpha1/instances.yaml
+++ b/hub/resourceeditors/redis.gcp.kubedb.com/v1alpha1/instances.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/releases.x-helm.dev/v1alpha1/bundles.yaml
+++ b/hub/resourceeditors/releases.x-helm.dev/v1alpha1/bundles.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/releases.x-helm.dev/v1alpha1/orders.yaml
+++ b/hub/resourceeditors/releases.x-helm.dev/v1alpha1/orders.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/repositories.stash.appscode.com/v1alpha1/snapshots.yaml
+++ b/hub/resourceeditors/repositories.stash.appscode.com/v1alpha1/snapshots.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/runtime.cluster.x-k8s.io/v1alpha1/extensionconfigs.yaml
+++ b/hub/resourceeditors/runtime.cluster.x-k8s.io/v1alpha1/extensionconfigs.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/scheduling.k8s.io/v1/priorityclasses.yaml
+++ b/hub/resourceeditors/scheduling.k8s.io/v1/priorityclasses.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/schema.kubedb.com/v1alpha1/mariadbdatabases.yaml
+++ b/hub/resourceeditors/schema.kubedb.com/v1alpha1/mariadbdatabases.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/schema.kubedb.com/v1alpha1/mongodbdatabases.yaml
+++ b/hub/resourceeditors/schema.kubedb.com/v1alpha1/mongodbdatabases.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/schema.kubedb.com/v1alpha1/mysqldatabases.yaml
+++ b/hub/resourceeditors/schema.kubedb.com/v1alpha1/mysqldatabases.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/schema.kubedb.com/v1alpha1/postgresdatabases.yaml
+++ b/hub/resourceeditors/schema.kubedb.com/v1alpha1/postgresdatabases.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/secrets-store.csi.x-k8s.io/v1/secretproviderclasses.yaml
+++ b/hub/resourceeditors/secrets-store.csi.x-k8s.io/v1/secretproviderclasses.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/secrets-store.csi.x-k8s.io/v1/secretproviderclasspodstatuses.yaml
+++ b/hub/resourceeditors/secrets-store.csi.x-k8s.io/v1/secretproviderclasspodstatuses.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/secrets-store.csi.x-k8s.io/v1alpha1/secretproviderclasses.yaml
+++ b/hub/resourceeditors/secrets-store.csi.x-k8s.io/v1alpha1/secretproviderclasses.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/secrets-store.csi.x-k8s.io/v1alpha1/secretproviderclasspodstatuses.yaml
+++ b/hub/resourceeditors/secrets-store.csi.x-k8s.io/v1alpha1/secretproviderclasspodstatuses.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/secrets.crossplane.io/v1alpha1/storeconfigs.yaml
+++ b/hub/resourceeditors/secrets.crossplane.io/v1alpha1/storeconfigs.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/secretsmanager.aws.kubedb.com/v1alpha1/secrets.yaml
+++ b/hub/resourceeditors/secretsmanager.aws.kubedb.com/v1alpha1/secrets.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/settings.k8s.io/v1alpha1/podpresets.yaml
+++ b/hub/resourceeditors/settings.k8s.io/v1alpha1/podpresets.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshotclasses.yaml
+++ b/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshotclasses.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshotcontents.yaml
+++ b/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshotcontents.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshots.yaml
+++ b/hub/resourceeditors/snapshot.storage.k8s.io/v1/volumesnapshots.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/sns.aws.kubedb.com/v1alpha1/topics.yaml
+++ b/hub/resourceeditors/sns.aws.kubedb.com/v1alpha1/topics.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/source.toolkit.fluxcd.io/v1/gitrepositories.yaml
+++ b/hub/resourceeditors/source.toolkit.fluxcd.io/v1/gitrepositories.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/source.toolkit.fluxcd.io/v1/helmcharts.yaml
+++ b/hub/resourceeditors/source.toolkit.fluxcd.io/v1/helmcharts.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/source.toolkit.fluxcd.io/v1/helmrepositories.yaml
+++ b/hub/resourceeditors/source.toolkit.fluxcd.io/v1/helmrepositories.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/buckets.yaml
+++ b/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/buckets.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/gitrepositories.yaml
+++ b/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/gitrepositories.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/helmcharts.yaml
+++ b/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/helmcharts.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/helmrepositories.yaml
+++ b/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/helmrepositories.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/ocirepositories.yaml
+++ b/hub/resourceeditors/source.toolkit.fluxcd.io/v1beta2/ocirepositories.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/spanner.gcp.kubedb.com/v1alpha1/databaseiammembers.yaml
+++ b/hub/resourceeditors/spanner.gcp.kubedb.com/v1alpha1/databaseiammembers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/spanner.gcp.kubedb.com/v1alpha1/databases.yaml
+++ b/hub/resourceeditors/spanner.gcp.kubedb.com/v1alpha1/databases.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/spanner.gcp.kubedb.com/v1alpha1/instanceiammembers.yaml
+++ b/hub/resourceeditors/spanner.gcp.kubedb.com/v1alpha1/instanceiammembers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/spanner.gcp.kubedb.com/v1alpha1/instances.yaml
+++ b/hub/resourceeditors/spanner.gcp.kubedb.com/v1alpha1/instances.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqldatabases.yaml
+++ b/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqldatabases.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqldatabasevulnerabilityassessmentrulebaselines.yaml
+++ b/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqldatabasevulnerabilityassessmentrulebaselines.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlelasticpools.yaml
+++ b/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlelasticpools.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlfailovergroups.yaml
+++ b/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlfailovergroups.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlfirewallrules.yaml
+++ b/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlfirewallrules.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqljobagents.yaml
+++ b/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqljobagents.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqljobcredentials.yaml
+++ b/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqljobcredentials.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlmanageddatabases.yaml
+++ b/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlmanageddatabases.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlmanagedinstanceactivedirectoryadministrators.yaml
+++ b/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlmanagedinstanceactivedirectoryadministrators.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlmanagedinstancefailovergroups.yaml
+++ b/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlmanagedinstancefailovergroups.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlmanagedinstances.yaml
+++ b/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlmanagedinstances.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlmanagedinstancevulnerabilityassessments.yaml
+++ b/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlmanagedinstancevulnerabilityassessments.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqloutboundfirewallrules.yaml
+++ b/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqloutboundfirewallrules.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlserverdnsaliases.yaml
+++ b/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlserverdnsaliases.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlservermicrosoftsupportauditingpolicies.yaml
+++ b/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlservermicrosoftsupportauditingpolicies.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlservers.yaml
+++ b/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlservers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlserversecurityalertpolicies.yaml
+++ b/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlserversecurityalertpolicies.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlservertransparentdataencryptions.yaml
+++ b/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlservertransparentdataencryptions.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlservervulnerabilityassessments.yaml
+++ b/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlservervulnerabilityassessments.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlvirtualnetworkrules.yaml
+++ b/hub/resourceeditors/sql.azure.kubedb.com/v1alpha1/mssqlvirtualnetworkrules.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/sql.gcp.kubedb.com/v1alpha1/databaseinstances.yaml
+++ b/hub/resourceeditors/sql.gcp.kubedb.com/v1alpha1/databaseinstances.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/sql.gcp.kubedb.com/v1alpha1/databases.yaml
+++ b/hub/resourceeditors/sql.gcp.kubedb.com/v1alpha1/databases.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/sql.gcp.kubedb.com/v1alpha1/sourcerepresentationinstances.yaml
+++ b/hub/resourceeditors/sql.gcp.kubedb.com/v1alpha1/sourcerepresentationinstances.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/sql.gcp.kubedb.com/v1alpha1/sslcerts.yaml
+++ b/hub/resourceeditors/sql.gcp.kubedb.com/v1alpha1/sslcerts.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/sql.gcp.kubedb.com/v1alpha1/users.yaml
+++ b/hub/resourceeditors/sql.gcp.kubedb.com/v1alpha1/users.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/stash.appscode.com/v1alpha1/recoveries.yaml
+++ b/hub/resourceeditors/stash.appscode.com/v1alpha1/recoveries.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/stash.appscode.com/v1alpha1/repositories.yaml
+++ b/hub/resourceeditors/stash.appscode.com/v1alpha1/repositories.yaml
@@ -25,7 +25,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false
     options:
@@ -33,5 +33,5 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0

--- a/hub/resourceeditors/stash.appscode.com/v1alpha1/restics.yaml
+++ b/hub/resourceeditors/stash.appscode.com/v1alpha1/restics.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/stash.appscode.com/v1beta1/backupbatches.yaml
+++ b/hub/resourceeditors/stash.appscode.com/v1beta1/backupbatches.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/stash.appscode.com/v1beta1/backupblueprints.yaml
+++ b/hub/resourceeditors/stash.appscode.com/v1beta1/backupblueprints.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/stash.appscode.com/v1beta1/backupconfigurations.yaml
+++ b/hub/resourceeditors/stash.appscode.com/v1beta1/backupconfigurations.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/stash.appscode.com/v1beta1/backupsessions.yaml
+++ b/hub/resourceeditors/stash.appscode.com/v1beta1/backupsessions.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/stash.appscode.com/v1beta1/functions.yaml
+++ b/hub/resourceeditors/stash.appscode.com/v1beta1/functions.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/stash.appscode.com/v1beta1/restorebatches.yaml
+++ b/hub/resourceeditors/stash.appscode.com/v1beta1/restorebatches.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/stash.appscode.com/v1beta1/restoresessions.yaml
+++ b/hub/resourceeditors/stash.appscode.com/v1beta1/restoresessions.yaml
@@ -25,7 +25,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false
     options:
@@ -33,5 +33,5 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0

--- a/hub/resourceeditors/stash.appscode.com/v1beta1/tasks.yaml
+++ b/hub/resourceeditors/stash.appscode.com/v1beta1/tasks.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/status.gatekeeper.sh/v1beta1/constraintpodstatuses.yaml
+++ b/hub/resourceeditors/status.gatekeeper.sh/v1beta1/constraintpodstatuses.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/status.gatekeeper.sh/v1beta1/constrainttemplatepodstatuses.yaml
+++ b/hub/resourceeditors/status.gatekeeper.sh/v1beta1/constrainttemplatepodstatuses.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/status.gatekeeper.sh/v1beta1/expansiontemplatepodstatuses.yaml
+++ b/hub/resourceeditors/status.gatekeeper.sh/v1beta1/expansiontemplatepodstatuses.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/status.gatekeeper.sh/v1beta1/mutatorpodstatuses.yaml
+++ b/hub/resourceeditors/status.gatekeeper.sh/v1beta1/mutatorpodstatuses.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/storage.azure.kubedb.com/v1alpha1/accounts.yaml
+++ b/hub/resourceeditors/storage.azure.kubedb.com/v1alpha1/accounts.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/storage.azure.kubedb.com/v1alpha1/containers.yaml
+++ b/hub/resourceeditors/storage.azure.kubedb.com/v1alpha1/containers.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/storage.k8s.io/v1/csidrivers.yaml
+++ b/hub/resourceeditors/storage.k8s.io/v1/csidrivers.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/storage.k8s.io/v1/csinodes.yaml
+++ b/hub/resourceeditors/storage.k8s.io/v1/csinodes.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/storage.k8s.io/v1/storageclasses.yaml
+++ b/hub/resourceeditors/storage.k8s.io/v1/storageclasses.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/storage.k8s.io/v1/volumeattachments.yaml
+++ b/hub/resourceeditors/storage.k8s.io/v1/volumeattachments.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/storage.k8s.io/v1beta1/csistoragecapacities.yaml
+++ b/hub/resourceeditors/storage.k8s.io/v1beta1/csistoragecapacities.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/storage.kubestash.com/v1alpha1/backupstorages.yaml
+++ b/hub/resourceeditors/storage.kubestash.com/v1alpha1/backupstorages.yaml
@@ -20,7 +20,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false
     options:
@@ -28,5 +28,5 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0

--- a/hub/resourceeditors/storage.kubestash.com/v1alpha1/repositories.yaml
+++ b/hub/resourceeditors/storage.kubestash.com/v1alpha1/repositories.yaml
@@ -25,7 +25,7 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false
     options:
@@ -33,5 +33,5 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0

--- a/hub/resourceeditors/storage.kubestash.com/v1alpha1/retentionpolicies.yaml
+++ b/hub/resourceeditors/storage.kubestash.com/v1alpha1/retentionpolicies.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/storage.kubestash.com/v1alpha1/snapshots.yaml
+++ b/hub/resourceeditors/storage.kubestash.com/v1alpha1/snapshots.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/supervisor.appscode.com/v1alpha1/approvalpolicies.yaml
+++ b/hub/resourceeditors/supervisor.appscode.com/v1alpha1/approvalpolicies.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/supervisor.appscode.com/v1alpha1/clustermaintenancewindows.yaml
+++ b/hub/resourceeditors/supervisor.appscode.com/v1alpha1/clustermaintenancewindows.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/supervisor.appscode.com/v1alpha1/maintenancewindows.yaml
+++ b/hub/resourceeditors/supervisor.appscode.com/v1alpha1/maintenancewindows.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/supervisor.appscode.com/v1alpha1/recommendations.yaml
+++ b/hub/resourceeditors/supervisor.appscode.com/v1alpha1/recommendations.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ui.k8s.appscode.com/v1alpha1/clusterprofiles.yaml
+++ b/hub/resourceeditors/ui.k8s.appscode.com/v1alpha1/clusterprofiles.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ui.k8s.appscode.com/v1alpha1/featuresets.yaml
+++ b/hub/resourceeditors/ui.k8s.appscode.com/v1alpha1/featuresets.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ui.k8s.appscode.com/v1alpha1/resourcedashboards.yaml
+++ b/hub/resourceeditors/ui.k8s.appscode.com/v1alpha1/resourcedashboards.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ui.k8s.appscode.com/v1alpha1/resourceeditors.yaml
+++ b/hub/resourceeditors/ui.k8s.appscode.com/v1alpha1/resourceeditors.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ui.k8s.appscode.com/v1alpha1/resourceoutlinefilters.yaml
+++ b/hub/resourceeditors/ui.k8s.appscode.com/v1alpha1/resourceoutlinefilters.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/databaseconnections.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/databaseconnections.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/databaseinfoes.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/databaseinfoes.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/elasticsearchinsights.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/elasticsearchinsights.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/elasticsearchnodesstats.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/elasticsearchnodesstats.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/elasticsearchschemaoverviews.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/elasticsearchschemaoverviews.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/mariadbinsights.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/mariadbinsights.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/mariadbqueries.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/mariadbqueries.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/mariadbschemaoverviews.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/mariadbschemaoverviews.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/mongodbinsights.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/mongodbinsights.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/mongodbqueries.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/mongodbqueries.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/mongodbschemaoverviews.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/mongodbschemaoverviews.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/mysqlinsights.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/mysqlinsights.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/mysqlqueries.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/mysqlqueries.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/mysqlschemaoverviews.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/mysqlschemaoverviews.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncerinsights.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncerinsights.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncerpooloverviews.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncerpooloverviews.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncerpools.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncerpools.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncerserveroverviews.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncerserveroverviews.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncersettings.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/pgbouncersettings.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/postgresinsights.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/postgresinsights.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/postgresqueries.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/postgresqueries.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/postgresschemaoverviews.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/postgresschemaoverviews.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/postgressettings.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/postgressettings.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/proxysqlinsights.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/proxysqlinsights.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/proxysqlqueries.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/proxysqlqueries.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/proxysqlsettings.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/proxysqlsettings.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/redisinsights.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/redisinsights.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/redisqueries.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/redisqueries.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ui.kubedb.com/v1alpha1/redisschemaoverviews.yaml
+++ b/hub/resourceeditors/ui.kubedb.com/v1alpha1/redisschemaoverviews.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/ui.stash.appscode.com/v1alpha1/backupoverviews.yaml
+++ b/hub/resourceeditors/ui.stash.appscode.com/v1alpha1/backupoverviews.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/virtual-secrets.dev/v1alpha1/secretmounts.yaml
+++ b/hub/resourceeditors/virtual-secrets.dev/v1alpha1/secretmounts.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/virtual-secrets.dev/v1alpha1/secrets.yaml
+++ b/hub/resourceeditors/virtual-secrets.dev/v1alpha1/secrets.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/voyager.appscode.com/v1/ingresses.yaml
+++ b/hub/resourceeditors/voyager.appscode.com/v1/ingresses.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/voyager.appscode.com/v1beta1/ingresses.yaml
+++ b/hub/resourceeditors/voyager.appscode.com/v1beta1/ingresses.yaml
@@ -25,6 +25,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/work.open-cluster-management.io/v1/appliedmanifestworks.yaml
+++ b/hub/resourceeditors/work.open-cluster-management.io/v1/appliedmanifestworks.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/work.open-cluster-management.io/v1/manifestworks.yaml
+++ b/hub/resourceeditors/work.open-cluster-management.io/v1/manifestworks.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false

--- a/hub/resourceeditors/work.open-cluster-management.io/v1alpha1/manifestworkreplicasets.yaml
+++ b/hub/resourceeditors/work.open-cluster-management.io/v1alpha1/manifestworkreplicasets.yaml
@@ -20,6 +20,6 @@ spec:
       sourceRef:
         apiGroup: source.toolkit.fluxcd.io
         kind: HelmRepository
-        name: appscode-charts-oci
+        name: appscode-wizards-oci
       version: v0.35.0
     enforceQuota: false


### PR DESCRIPTION
Renames the Helm `sourceRef.name` from `appscode-charts-oci` to `appscode-wizards-oci` across all resource editors in the hub.

This is a mechanical rename touching 811 resource editor YAML files (1271 occurrences), with no other changes.