### PR TITLE
Allow creating VaultServer from kubedb resource outlines

### DIFF
--- a/hub/resourceoutlines/kubedb.com/v1/kubedb/elasticsearches.yaml
+++ b/hub/resourceoutlines/kubedb.com/v1/kubedb/elasticsearches.yaml
@@ -248,7 +248,7 @@ spec:
         view:
           name: appcatalog.appscode.com-v1alpha1-appbindings
       - actions:
-          create: Never
+          create: Always
         displayMode: List
         kind: Connection
         name: VaultServers

--- a/hub/resourceoutlines/kubedb.com/v1/kubedb/mariadbs.yaml
+++ b/hub/resourceoutlines/kubedb.com/v1/kubedb/mariadbs.yaml
@@ -248,7 +248,7 @@ spec:
         view:
           name: appcatalog.appscode.com-v1alpha1-appbindings
       - actions:
-          create: Never
+          create: Always
         displayMode: List
         kind: Connection
         name: VaultServers

--- a/hub/resourceoutlines/kubedb.com/v1/kubedb/mongodbs.yaml
+++ b/hub/resourceoutlines/kubedb.com/v1/kubedb/mongodbs.yaml
@@ -251,7 +251,7 @@ spec:
         view:
           name: appcatalog.appscode.com-v1alpha1-appbindings
       - actions:
-          create: Never
+          create: Always
         displayMode: List
         kind: Connection
         name: VaultServers

--- a/hub/resourceoutlines/kubedb.com/v1/kubedb/mysqls.yaml
+++ b/hub/resourceoutlines/kubedb.com/v1/kubedb/mysqls.yaml
@@ -248,7 +248,7 @@ spec:
         view:
           name: appcatalog.appscode.com-v1alpha1-appbindings
       - actions:
-          create: Never
+          create: Always
         displayMode: List
         kind: Connection
         name: VaultServers

--- a/hub/resourceoutlines/kubedb.com/v1/kubedb/postgreses.yaml
+++ b/hub/resourceoutlines/kubedb.com/v1/kubedb/postgreses.yaml
@@ -284,7 +284,7 @@ spec:
         view:
           name: appcatalog.appscode.com-v1alpha1-appbindings
       - actions:
-          create: Never
+          create: Always
         displayMode: List
         kind: Connection
         name: VaultServers


### PR DESCRIPTION
Change the VaultServers connection block's `create` action from `Never` to `Always` in the kubedb.com/v1 resource outlines for mongodb, elasticsearch, postgres, mysql, and mariadb.