### PR TITLE
Modernize golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,27 +2,22 @@ version: "2"
 linters:
   default: standard
   enable:
+    - bodyclose
+    - prealloc
     - unparam
+  exclusions:
+    paths:
+      - generated.*\.go
+      - client
+      - vendor
 
 formatters:
   enable:
-    - gofmt
+    - gofumpt
     - goimports
-  settings:
-    gofmt:
-      rewrite-rules:
-        - pattern: 'interface{}'
-          replacement: 'any'
 
 issues:
   max-same-issues: 100
-
-  exclude-files:
-    - generated.*\\.go
-
-  exclude-dirs:
-    - client
-    - vendor
 
 run:
   timeout: 10m

--- a/apis/editor/v1alpha1/register.go
+++ b/apis/editor/v1alpha1/register.go
@@ -48,11 +48,13 @@ func Resource(resource string) schema.GroupResource {
 
 // Adds the list of known types to api.Scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
-	scheme.AddKnownTypes(SchemeGroupVersion,
+	scheme.AddKnownTypes(
+		SchemeGroupVersion,
 		&EditorModel{},
 	)
 
-	scheme.AddKnownTypes(SchemeGroupVersion,
+	scheme.AddKnownTypes(
+		SchemeGroupVersion,
 		&metav1.Status{},
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/apis/management/v1alpha1/register.go
+++ b/apis/management/v1alpha1/register.go
@@ -48,12 +48,14 @@ func Resource(resource string) schema.GroupResource {
 
 // Adds the list of known types to api.Scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
-	scheme.AddKnownTypes(SchemeGroupVersion,
+	scheme.AddKnownTypes(
+		SchemeGroupVersion,
 		&ProjectQuota{},
 		&ProjectQuotaList{},
 	)
 
-	scheme.AddKnownTypes(SchemeGroupVersion,
+	scheme.AddKnownTypes(
+		SchemeGroupVersion,
 		&metav1.Status{},
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/apis/meta/v1alpha1/register.go
+++ b/apis/meta/v1alpha1/register.go
@@ -48,7 +48,8 @@ func Resource(resource string) schema.GroupResource {
 
 // Adds the list of known types to api.Scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
-	scheme.AddKnownTypes(SchemeGroupVersion,
+	scheme.AddKnownTypes(
+		SchemeGroupVersion,
 		&ChartPresetQuery{},
 		&ClusterProfile{},
 		&ClusterProfileList{},
@@ -82,7 +83,8 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&RenderDashboard{},
 	)
 
-	scheme.AddKnownTypes(SchemeGroupVersion,
+	scheme.AddKnownTypes(
+		SchemeGroupVersion,
 		&metav1.Status{},
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/apis/node/v1alpha1/register.go
+++ b/apis/node/v1alpha1/register.go
@@ -48,12 +48,14 @@ func Resource(resource string) schema.GroupResource {
 
 // Adds the list of known types to api.Scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
-	scheme.AddKnownTypes(SchemeGroupVersion,
+	scheme.AddKnownTypes(
+		SchemeGroupVersion,
 		&NodeTopology{},
 		&NodeTopologyList{},
 	)
 
-	scheme.AddKnownTypes(SchemeGroupVersion,
+	scheme.AddKnownTypes(
+		SchemeGroupVersion,
 		&metav1.Status{},
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/apis/ui/v1alpha1/register.go
+++ b/apis/ui/v1alpha1/register.go
@@ -48,7 +48,8 @@ func Resource(resource string) schema.GroupResource {
 
 // Adds the list of known types to api.Scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
-	scheme.AddKnownTypes(SchemeGroupVersion,
+	scheme.AddKnownTypes(
+		SchemeGroupVersion,
 		&ClusterProfile{},
 		&ClusterProfileList{},
 		&Feature{},
@@ -63,7 +64,8 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&ResourceOutlineFilterList{},
 	)
 
-	scheme.AddKnownTypes(SchemeGroupVersion,
+	scheme.AddKnownTypes(
+		SchemeGroupVersion,
 		&metav1.Status{},
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/pkg/tableconvertor/util.go
+++ b/pkg/tableconvertor/util.go
@@ -320,16 +320,16 @@ func describeVolume(volume core.Volume) string {
 			sources.WriteString("{")
 			if source.Secret != nil {
 				sources.WriteString("\"Type\": \"Secret\",")
-				sources.WriteString(fmt.Sprintf("\"SecretName\": %q", source.Secret.Name))
+				fmt.Fprintf(&sources, "\"SecretName\": %q", source.Secret.Name)
 			} else if source.DownwardAPI != nil {
 				sources.WriteString("\"Type\": \"DownwardAPI\",")
 				sources.WriteString("\"DownwardAPI\": \"true\"")
 			} else if source.ConfigMap != nil {
 				sources.WriteString("\"Type\": \"ConfigMap\",")
-				sources.WriteString(fmt.Sprintf("\"ConfigMapName\": %q", source.ConfigMap.Name))
+				fmt.Fprintf(&sources, "\"ConfigMapName\": %q", source.ConfigMap.Name)
 			} else if source.ServiceAccountToken != nil {
 				sources.WriteString("\"Type\": \"ServiceAccountToken\",")
-				sources.WriteString(fmt.Sprintf("\"TokenExpirationSeconds\": \"%v\"", source.ServiceAccountToken.ExpirationSeconds))
+				fmt.Fprintf(&sources, "\"TokenExpirationSeconds\": \"%v\"", source.ServiceAccountToken.ExpirationSeconds)
 			}
 			sources.WriteString("}")
 			if i < len(projected.Sources)-1 {


### PR DESCRIPTION
## Summary

Modernize the `.golangci.yml` configuration for golangci-lint v2 and switch the configured formatter to gofumpt.

This also aligns the linter with the build image (`ghcr.io/appscode/golang-dev:1.25`), where `gofmt` is already a symlink shim to **gofumpt v0.7.0** — so `make fmt` (via `hack/fmt.sh`'s `gofmt -s -w`) and the linter now enforce the same formatting. No change to `hack/fmt.sh` is needed.

### `.golangci.yml`
- Enable **`bodyclose`** and **`prealloc`** linters (`unparam` was already enabled).
- Move `exclude-files` / `exclude-dirs` out of the deprecated `issues:` block into **`linters.exclusions.paths`** — the correct location in golangci-lint v2.
- Fix the over-escaped exclusion regex `generated.*\\.go` → `generated.*\.go` (the double backslash matched a literal backslash rather than a dot).
- Switch the formatter from **`gofmt` → `gofumpt`** and drop the now-unneeded `interface{}` → `any` rewrite rule (gofumpt performs this itself at go1.18+, and go.mod pins go1.25).

`golangci-lint config verify` passes and `golangci-lint run` reports 0 issues.

### Resulting formatting
- gofumpt reformat of five `apis/**/register.go` files (`AddKnownTypes` argument wrapping).
- `pkg/tableconvertor/util.go`: use `fmt.Fprintf(&sources, ...)` instead of `sources.WriteString(fmt.Sprintf(...))`.

## Test plan
- [x] `golangci-lint config verify` — valid
- [x] `golangci-lint run` — 0 issues
- [x] `go build ./pkg/tableconvertor/...`