### PR TITLE
Add ops connections and recommendation blocks for newer databases

### DIFF
--- a/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/aerospikeopsrequests.yaml
+++ b/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/aerospikeopsrequests.yaml
@@ -8,6 +8,15 @@ metadata:
     k8s.io/version: v1alpha1
   name: ops.kubedb.com-v1alpha1-aerospikeopsrequests
 spec:
+  connections:
+  - labels:
+    - ops
+    references:
+    - '{.spec.databaseRef.name}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: Aerospike
+    type: MatchRef
   resource:
     group: ops.kubedb.com
     kind: AerospikeOpsRequest

--- a/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/cassandraopsrequests.yaml
+++ b/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/cassandraopsrequests.yaml
@@ -8,6 +8,15 @@ metadata:
     k8s.io/version: v1alpha1
   name: ops.kubedb.com-v1alpha1-cassandraopsrequests
 spec:
+  connections:
+  - labels:
+    - ops
+    references:
+    - '{.spec.databaseRef.name}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: Cassandra
+    type: MatchRef
   resource:
     group: ops.kubedb.com
     kind: CassandraOpsRequest

--- a/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/clickhouseopsrequests.yaml
+++ b/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/clickhouseopsrequests.yaml
@@ -8,6 +8,15 @@ metadata:
     k8s.io/version: v1alpha1
   name: ops.kubedb.com-v1alpha1-clickhouseopsrequests
 spec:
+  connections:
+  - labels:
+    - ops
+    references:
+    - '{.spec.databaseRef.name}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: ClickHouse
+    type: MatchRef
   resource:
     group: ops.kubedb.com
     kind: ClickHouseOpsRequest

--- a/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/db2opsrequests.yaml
+++ b/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/db2opsrequests.yaml
@@ -8,6 +8,15 @@ metadata:
     k8s.io/version: v1alpha1
   name: ops.kubedb.com-v1alpha1-db2opsrequests
 spec:
+  connections:
+  - labels:
+    - ops
+    references:
+    - '{.spec.databaseRef.name}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: DB2
+    type: MatchRef
   resource:
     group: ops.kubedb.com
     kind: DB2OpsRequest

--- a/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/documentdbopsrequests.yaml
+++ b/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/documentdbopsrequests.yaml
@@ -8,6 +8,15 @@ metadata:
     k8s.io/version: v1alpha1
   name: ops.kubedb.com-v1alpha1-documentdbopsrequests
 spec:
+  connections:
+  - labels:
+    - ops
+    references:
+    - '{.spec.databaseRef.name}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: DocumentDB
+    type: MatchRef
   resource:
     group: ops.kubedb.com
     kind: DocumentDBOpsRequest

--- a/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/etcdopsrequests.yaml
+++ b/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/etcdopsrequests.yaml
@@ -8,6 +8,15 @@ metadata:
     k8s.io/version: v1alpha1
   name: ops.kubedb.com-v1alpha1-etcdopsrequests
 spec:
+  connections:
+  - labels:
+    - ops
+    references:
+    - '{.spec.databaseRef.name}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: Etcd
+    type: MatchRef
   resource:
     group: ops.kubedb.com
     kind: EtcdOpsRequest

--- a/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/hanadbopsrequests.yaml
+++ b/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/hanadbopsrequests.yaml
@@ -8,6 +8,15 @@ metadata:
     k8s.io/version: v1alpha1
   name: ops.kubedb.com-v1alpha1-hanadbopsrequests
 spec:
+  connections:
+  - labels:
+    - ops
+    references:
+    - '{.spec.databaseRef.name}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: HanaDB
+    type: MatchRef
   resource:
     group: ops.kubedb.com
     kind: HanaDBOpsRequest

--- a/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/hazelcastopsrequests.yaml
+++ b/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/hazelcastopsrequests.yaml
@@ -8,6 +8,15 @@ metadata:
     k8s.io/version: v1alpha1
   name: ops.kubedb.com-v1alpha1-hazelcastopsrequests
 spec:
+  connections:
+  - labels:
+    - ops
+    references:
+    - '{.spec.databaseRef.name}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: Hazelcast
+    type: MatchRef
   resource:
     group: ops.kubedb.com
     kind: HazelcastOpsRequest

--- a/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/igniteopsrequests.yaml
+++ b/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/igniteopsrequests.yaml
@@ -8,6 +8,15 @@ metadata:
     k8s.io/version: v1alpha1
   name: ops.kubedb.com-v1alpha1-igniteopsrequests
 spec:
+  connections:
+  - labels:
+    - ops
+    references:
+    - '{.spec.databaseRef.name}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: Ignite
+    type: MatchRef
   resource:
     group: ops.kubedb.com
     kind: IgniteOpsRequest

--- a/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/milvusopsrequests.yaml
+++ b/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/milvusopsrequests.yaml
@@ -8,6 +8,15 @@ metadata:
     k8s.io/version: v1alpha1
   name: ops.kubedb.com-v1alpha1-milvusopsrequests
 spec:
+  connections:
+  - labels:
+    - ops
+    references:
+    - '{.spec.databaseRef.name}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: Milvus
+    type: MatchRef
   resource:
     group: ops.kubedb.com
     kind: MilvusOpsRequest

--- a/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/neo4jopsrequests.yaml
+++ b/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/neo4jopsrequests.yaml
@@ -8,6 +8,15 @@ metadata:
     k8s.io/version: v1alpha1
   name: ops.kubedb.com-v1alpha1-neo4jopsrequests
 spec:
+  connections:
+  - labels:
+    - ops
+    references:
+    - '{.spec.databaseRef.name}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: Neo4j
+    type: MatchRef
   resource:
     group: ops.kubedb.com
     kind: Neo4jOpsRequest

--- a/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/oracleopsrequests.yaml
+++ b/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/oracleopsrequests.yaml
@@ -8,6 +8,15 @@ metadata:
     k8s.io/version: v1alpha1
   name: ops.kubedb.com-v1alpha1-oracleopsrequests
 spec:
+  connections:
+  - labels:
+    - ops
+    references:
+    - '{.spec.databaseRef.name}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: Oracle
+    type: MatchRef
   resource:
     group: ops.kubedb.com
     kind: OracleOpsRequest

--- a/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/qdrantopsrequests.yaml
+++ b/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/qdrantopsrequests.yaml
@@ -8,6 +8,15 @@ metadata:
     k8s.io/version: v1alpha1
   name: ops.kubedb.com-v1alpha1-qdrantopsrequests
 spec:
+  connections:
+  - labels:
+    - ops
+    references:
+    - '{.spec.databaseRef.name}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: Qdrant
+    type: MatchRef
   resource:
     group: ops.kubedb.com
     kind: QdrantOpsRequest

--- a/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/weaviateopsrequests.yaml
+++ b/hub/resourcedescriptors/ops.kubedb.com/v1alpha1/weaviateopsrequests.yaml
@@ -8,6 +8,15 @@ metadata:
     k8s.io/version: v1alpha1
   name: ops.kubedb.com-v1alpha1-weaviateopsrequests
 spec:
+  connections:
+  - labels:
+    - ops
+    references:
+    - '{.spec.databaseRef.name}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: Weaviate
+    type: MatchRef
   resource:
     group: ops.kubedb.com
     kind: WeaviateOpsRequest

--- a/hub/resourceoutlines/kubedb.com/v1alpha2/kubedb/cassandras.yaml
+++ b/hub/resourceoutlines/kubedb.com/v1alpha2/kubedb/cassandras.yaml
@@ -170,6 +170,27 @@ spec:
           sort:
             fieldName: Age
             order: Ascending
+      - actions:
+          create: Never
+        displayMode: List
+        kind: Connection
+        name: Recommendations
+        query:
+          byLabel: recommended_for
+          type: GraphQL
+        ref:
+          group: supervisor.appscode.com
+          kind: Recommendation
+        requiredFeatureSets:
+          opscenter-datastore:
+          - kubedb
+          opscenter-tools:
+          - supervisor
+        view:
+          name: supervisor.appscode.com-v1alpha1-recommendations-kubedb
+          sort:
+            fieldName: Age
+            order: Ascending
   - icon: carbon:data-backup
     name: Backup
     requiredFeatureSets:

--- a/hub/resourceoutlines/kubedb.com/v1alpha2/kubedb/ignites.yaml
+++ b/hub/resourceoutlines/kubedb.com/v1alpha2/kubedb/ignites.yaml
@@ -170,6 +170,27 @@ spec:
           sort:
             fieldName: Age
             order: Ascending
+      - actions:
+          create: Never
+        displayMode: List
+        kind: Connection
+        name: Recommendations
+        query:
+          byLabel: recommended_for
+          type: GraphQL
+        ref:
+          group: supervisor.appscode.com
+          kind: Recommendation
+        requiredFeatureSets:
+          opscenter-datastore:
+          - kubedb
+          opscenter-tools:
+          - supervisor
+        view:
+          name: supervisor.appscode.com-v1alpha1-recommendations-kubedb
+          sort:
+            fieldName: Age
+            order: Ascending
   - icon: hugeicons:database-locked
     name: Security
     sections:

--- a/hub/resourceoutlines/kubedb.com/v1alpha2/kubedb/milvuses.yaml
+++ b/hub/resourceoutlines/kubedb.com/v1alpha2/kubedb/milvuses.yaml
@@ -145,6 +145,27 @@ spec:
           sort:
             fieldName: Age
             order: Ascending
+      - actions:
+          create: Never
+        displayMode: List
+        kind: Connection
+        name: Recommendations
+        query:
+          byLabel: recommended_for
+          type: GraphQL
+        ref:
+          group: supervisor.appscode.com
+          kind: Recommendation
+        requiredFeatureSets:
+          opscenter-datastore:
+          - kubedb
+          opscenter-tools:
+          - supervisor
+        view:
+          name: supervisor.appscode.com-v1alpha1-recommendations-kubedb
+          sort:
+            fieldName: Age
+            order: Ascending
   - icon: hugeicons:database-locked
     name: Security
     sections:

--- a/hub/resourceoutlines/kubedb.com/v1alpha2/kubedb/neo4js.yaml
+++ b/hub/resourceoutlines/kubedb.com/v1alpha2/kubedb/neo4js.yaml
@@ -189,6 +189,27 @@ spec:
           sort:
             fieldName: Age
             order: Ascending
+      - actions:
+          create: Never
+        displayMode: List
+        kind: Connection
+        name: Recommendations
+        query:
+          byLabel: recommended_for
+          type: GraphQL
+        ref:
+          group: supervisor.appscode.com
+          kind: Recommendation
+        requiredFeatureSets:
+          opscenter-datastore:
+          - kubedb
+          opscenter-tools:
+          - supervisor
+        view:
+          name: supervisor.appscode.com-v1alpha1-recommendations-kubedb
+          sort:
+            fieldName: Age
+            order: Ascending
   - icon: carbon:data-backup
     name: Backup
     requiredFeatureSets:

--- a/hub/resourceoutlines/kubedb.com/v1alpha2/kubedb/oracles.yaml
+++ b/hub/resourceoutlines/kubedb.com/v1alpha2/kubedb/oracles.yaml
@@ -261,6 +261,27 @@ spec:
           sort:
             fieldName: Age
             order: Ascending
+      - actions:
+          create: Never
+        displayMode: List
+        kind: Connection
+        name: Recommendations
+        query:
+          byLabel: recommended_for
+          type: GraphQL
+        ref:
+          group: supervisor.appscode.com
+          kind: Recommendation
+        requiredFeatureSets:
+          opscenter-datastore:
+          - kubedb
+          opscenter-tools:
+          - supervisor
+        view:
+          name: supervisor.appscode.com-v1alpha1-recommendations-kubedb
+          sort:
+            fieldName: Age
+            order: Ascending
   - icon: hugeicons:database-locked
     name: Security
     sections:

--- a/hub/resourceoutlines/kubedb.com/v1alpha2/kubedb/qdrants.yaml
+++ b/hub/resourceoutlines/kubedb.com/v1alpha2/kubedb/qdrants.yaml
@@ -145,6 +145,27 @@ spec:
           sort:
             fieldName: Age
             order: Ascending
+      - actions:
+          create: Never
+        displayMode: List
+        kind: Connection
+        name: Recommendations
+        query:
+          byLabel: recommended_for
+          type: GraphQL
+        ref:
+          group: supervisor.appscode.com
+          kind: Recommendation
+        requiredFeatureSets:
+          opscenter-datastore:
+          - kubedb
+          opscenter-tools:
+          - supervisor
+        view:
+          name: supervisor.appscode.com-v1alpha1-recommendations-kubedb
+          sort:
+            fieldName: Age
+            order: Ascending
   - icon: hugeicons:database-locked
     name: Security
     sections:

--- a/hub/resourceoutlines/kubedb.com/v1alpha2/kubedb/rabbitmqs.yaml
+++ b/hub/resourceoutlines/kubedb.com/v1alpha2/kubedb/rabbitmqs.yaml
@@ -261,6 +261,27 @@ spec:
           sort:
             fieldName: Age
             order: Ascending
+      - actions:
+          create: Never
+        displayMode: List
+        kind: Connection
+        name: Recommendations
+        query:
+          byLabel: recommended_for
+          type: GraphQL
+        ref:
+          group: supervisor.appscode.com
+          kind: Recommendation
+        requiredFeatureSets:
+          opscenter-datastore:
+          - kubedb
+          opscenter-tools:
+          - supervisor
+        view:
+          name: supervisor.appscode.com-v1alpha1-recommendations-kubedb
+          sort:
+            fieldName: Age
+            order: Ascending
   - icon: hugeicons:database-locked
     name: Security
     sections:

--- a/hub/resourceoutlines/kubedb.com/v1alpha2/kubedb/singlestores.yaml
+++ b/hub/resourceoutlines/kubedb.com/v1alpha2/kubedb/singlestores.yaml
@@ -261,6 +261,27 @@ spec:
           sort:
             fieldName: Age
             order: Ascending
+      - actions:
+          create: Never
+        displayMode: List
+        kind: Connection
+        name: Recommendations
+        query:
+          byLabel: recommended_for
+          type: GraphQL
+        ref:
+          group: supervisor.appscode.com
+          kind: Recommendation
+        requiredFeatureSets:
+          opscenter-datastore:
+          - kubedb
+          opscenter-tools:
+          - supervisor
+        view:
+          name: supervisor.appscode.com-v1alpha1-recommendations-kubedb
+          sort:
+            fieldName: Age
+            order: Ascending
   - icon: carbon:data-backup
     name: Backup
     requiredFeatureSets:

--- a/hub/resourceoutlines/kubedb.com/v1alpha2/kubedb/solrs.yaml
+++ b/hub/resourceoutlines/kubedb.com/v1alpha2/kubedb/solrs.yaml
@@ -261,6 +261,27 @@ spec:
           sort:
             fieldName: Age
             order: Ascending
+      - actions:
+          create: Never
+        displayMode: List
+        kind: Connection
+        name: Recommendations
+        query:
+          byLabel: recommended_for
+          type: GraphQL
+        ref:
+          group: supervisor.appscode.com
+          kind: Recommendation
+        requiredFeatureSets:
+          opscenter-datastore:
+          - kubedb
+          opscenter-tools:
+          - supervisor
+        view:
+          name: supervisor.appscode.com-v1alpha1-recommendations-kubedb
+          sort:
+            fieldName: Age
+            order: Ascending
   - icon: hugeicons:database-locked
     name: Security
     sections:

--- a/hub/resourceoutlines/kubedb.com/v1alpha2/kubedb/weaviates.yaml
+++ b/hub/resourceoutlines/kubedb.com/v1alpha2/kubedb/weaviates.yaml
@@ -106,6 +106,27 @@ spec:
           sort:
             fieldName: Age
             order: Ascending
+      - actions:
+          create: Never
+        displayMode: List
+        kind: Connection
+        name: Recommendations
+        query:
+          byLabel: recommended_for
+          type: GraphQL
+        ref:
+          group: supervisor.appscode.com
+          kind: Recommendation
+        requiredFeatureSets:
+          opscenter-datastore:
+          - kubedb
+          opscenter-tools:
+          - supervisor
+        view:
+          name: supervisor.appscode.com-v1alpha1-recommendations-kubedb
+          sort:
+            fieldName: Age
+            order: Ascending
   - icon: hugeicons:database-locked
     name: Security
     sections:

--- a/hub/resourceoutlines/kubedb.com/v1alpha2/kubedb/zookeepers.yaml
+++ b/hub/resourceoutlines/kubedb.com/v1alpha2/kubedb/zookeepers.yaml
@@ -170,6 +170,27 @@ spec:
           sort:
             fieldName: Age
             order: Ascending
+      - actions:
+          create: Never
+        displayMode: List
+        kind: Connection
+        name: Recommendations
+        query:
+          byLabel: recommended_for
+          type: GraphQL
+        ref:
+          group: supervisor.appscode.com
+          kind: Recommendation
+        requiredFeatureSets:
+          opscenter-datastore:
+          - kubedb
+          opscenter-tools:
+          - supervisor
+        view:
+          name: supervisor.appscode.com-v1alpha1-recommendations-kubedb
+          sort:
+            fieldName: Age
+            order: Ascending
   - icon: carbon:data-backup
     name: Backup
     requiredFeatureSets:


### PR DESCRIPTION
### ResourceDescriptors — `hub/resourcedescriptors/ops.kubedb.com/v1alpha1/`

Added `spec.connections` (the same `MatchRef` on `{.spec.databaseRef.name}` with the `ops` label that `mysqlopsrequests.yaml` already had) to the 14 ops RDs that were missing it:

aerospike, cassandra, clickhouse, db2, documentdb, etcd, hanadb, hazelcast, ignite, milvus, neo4j, oracle, qdrant, weaviate

Target `apiVersion` is `kubedb.com/v1alpha2` for all 14 — those kinds exist only under v1alpha2 (unlike MySQL, which points at `kubedb.com/v1`). Kinds taken from the corresponding `hub/resourcedescriptors/kubedb.com/v1alpha2/*.yaml` labels (`DB2`, `DocumentDB`, `HanaDB`, `ClickHouse`, `Neo4j`, `Etcd`, …).

### ResourceOutlines — `hub/resourceoutlines/kubedb.com/v1alpha2/kubedb/`

Added the supervisor `Recommendations` block to the Operations page (right after `Recent Operations`, matching `v1/kubedb/mongodbs.yaml`) of the 11 outlines that were missing it:

cassandras, ignites, milvuses, neo4js, oracles, qdrants, rabbitmqs, singlestores, solrs, weaviates, zookeepers

The block is byte-identical to the existing copies in `clickhouses.yaml` / `druids.yaml`.

### Deliberately not included

- `v1alpha2/kubedb/kafkas.yaml` has no Operations page at all, so there is nowhere to append the block — adding one would mean creating the whole page. `v1/kubedb/kafkas.yaml` already has both blocks.
- `db2s.yaml`, `documentdbs.yaml`, `hanadbs.yaml` outlines were left alone — those DBs are not in the supervisor recommender set.

### Verification

`cmd/resource-fmt` produces no further diff, `cmd/check-edge-label` and `cmd/check-embed` exit 0, `go build ./...` is clean. `make fmt` could not run locally (Docker daemon down), but the native `resource-fmt` / `check-edge-label` passes cover the two hub-specific passes it wraps.