### PR TITLE
Normalize kubedb connections and add missing dbs to recommendation/backup RDs

### DIFF
--- a/hub/resourcedescriptors/core.kubestash.com/v1alpha1/backupconfigurations.yaml
+++ b/hub/resourcedescriptors/core.kubestash.com/v1alpha1/backupconfigurations.yaml
@@ -46,6 +46,54 @@ spec:
     references:
     - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
     target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: Aerospike
+    type: MatchRef
+  - labels:
+    - backup_via
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: Cassandra
+    type: MatchRef
+  - labels:
+    - backup_via
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: ClickHouse
+    type: MatchRef
+  - labels:
+    - backup_via
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: DB2
+    type: MatchRef
+  - labels:
+    - backup_via
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: DocumentDB
+    type: MatchRef
+  - labels:
+    - backup_via
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: Druid
+    type: MatchRef
+  - labels:
+    - backup_via
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
       apiVersion: kubedb.com/v1
       kind: Elasticsearch
     type: MatchRef
@@ -54,8 +102,56 @@ spec:
     references:
     - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
     target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: HanaDB
+    type: MatchRef
+  - labels:
+    - backup_via
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: Hazelcast
+    type: MatchRef
+  - labels:
+    - backup_via
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: Ignite
+    type: MatchRef
+  - labels:
+    - backup_via
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1
+      kind: Kafka
+    type: MatchRef
+  - labels:
+    - backup_via
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
       apiVersion: kubedb.com/v1
       kind: MariaDB
+    type: MatchRef
+  - labels:
+    - backup_via
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1
+      kind: Memcached
+    type: MatchRef
+  - labels:
+    - backup_via
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: Milvus
     type: MatchRef
   - labels:
     - backup_via
@@ -86,6 +182,22 @@ spec:
     references:
     - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
     target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: Neo4j
+    type: MatchRef
+  - labels:
+    - backup_via
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: Oracle
+    type: MatchRef
+  - labels:
+    - backup_via
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
       apiVersion: kubedb.com/v1
       kind: PerconaXtraDB
     type: MatchRef
@@ -95,7 +207,47 @@ spec:
     - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
     target:
       apiVersion: kubedb.com/v1
+      kind: PgBouncer
+    type: MatchRef
+  - labels:
+    - backup_via
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: Pgpool
+    type: MatchRef
+  - labels:
+    - backup_via
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1
       kind: Postgres
+    type: MatchRef
+  - labels:
+    - backup_via
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1
+      kind: ProxySQL
+    type: MatchRef
+  - labels:
+    - backup_via
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: Qdrant
+    type: MatchRef
+  - labels:
+    - backup_via
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: RabbitMQ
     type: MatchRef
   - labels:
     - backup_via
@@ -112,6 +264,30 @@ spec:
     target:
       apiVersion: kubedb.com/v1alpha2
       kind: Singlestore
+    type: MatchRef
+  - labels:
+    - backup_via
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: Solr
+    type: MatchRef
+  - labels:
+    - backup_via
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: Weaviate
+    type: MatchRef
+  - labels:
+    - backup_via
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: ZooKeeper
     type: MatchRef
   resource:
     group: core.kubestash.com

--- a/hub/resourcedescriptors/core.kubestash.com/v1alpha1/restoresessions.yaml
+++ b/hub/resourcedescriptors/core.kubestash.com/v1alpha1/restoresessions.yaml
@@ -38,6 +38,54 @@ spec:
     references:
     - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
     target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: Aerospike
+    type: MatchRef
+  - labels:
+    - restore_into
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: Cassandra
+    type: MatchRef
+  - labels:
+    - restore_into
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: ClickHouse
+    type: MatchRef
+  - labels:
+    - restore_into
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: DB2
+    type: MatchRef
+  - labels:
+    - restore_into
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: DocumentDB
+    type: MatchRef
+  - labels:
+    - restore_into
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: Druid
+    type: MatchRef
+  - labels:
+    - restore_into
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
       apiVersion: kubedb.com/v1
       kind: Elasticsearch
     type: MatchRef
@@ -46,8 +94,56 @@ spec:
     references:
     - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
     target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: HanaDB
+    type: MatchRef
+  - labels:
+    - restore_into
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: Hazelcast
+    type: MatchRef
+  - labels:
+    - restore_into
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: Ignite
+    type: MatchRef
+  - labels:
+    - restore_into
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1
+      kind: Kafka
+    type: MatchRef
+  - labels:
+    - restore_into
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
       apiVersion: kubedb.com/v1
       kind: MariaDB
+    type: MatchRef
+  - labels:
+    - restore_into
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1
+      kind: Memcached
+    type: MatchRef
+  - labels:
+    - restore_into
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: Milvus
     type: MatchRef
   - labels:
     - restore_into
@@ -78,6 +174,22 @@ spec:
     references:
     - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
     target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: Neo4j
+    type: MatchRef
+  - labels:
+    - restore_into
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: Oracle
+    type: MatchRef
+  - labels:
+    - restore_into
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
       apiVersion: kubedb.com/v1
       kind: PerconaXtraDB
     type: MatchRef
@@ -87,7 +199,47 @@ spec:
     - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
     target:
       apiVersion: kubedb.com/v1
+      kind: PgBouncer
+    type: MatchRef
+  - labels:
+    - restore_into
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: Pgpool
+    type: MatchRef
+  - labels:
+    - restore_into
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1
       kind: Postgres
+    type: MatchRef
+  - labels:
+    - restore_into
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1
+      kind: ProxySQL
+    type: MatchRef
+  - labels:
+    - restore_into
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: Qdrant
+    type: MatchRef
+  - labels:
+    - restore_into
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: RabbitMQ
     type: MatchRef
   - labels:
     - restore_into
@@ -104,6 +256,30 @@ spec:
     target:
       apiVersion: kubedb.com/v1alpha2
       kind: Singlestore
+    type: MatchRef
+  - labels:
+    - restore_into
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: Solr
+    type: MatchRef
+  - labels:
+    - restore_into
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: Weaviate
+    type: MatchRef
+  - labels:
+    - restore_into
+    references:
+    - '{.spec.target.name},{.spec.target.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: ZooKeeper
     type: MatchRef
   resource:
     group: core.kubestash.com

--- a/hub/resourcedescriptors/kubedb.com/v1/elasticsearches.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1/elasticsearches.yaml
@@ -24,6 +24,16 @@ spec:
       kind: PetSet
     type: MatchSelector
   - labels:
+    - connect_via
+    level: Controller
+    nameTemplate: '{.metadata.name}'
+    namespace:
+      path: metadata.namespace
+    target:
+      apiVersion: appcatalog.appscode.com/v1alpha1
+      kind: AppBinding
+    type: MatchName
+  - labels:
     - auth_secret
     references:
     - '{.spec.authSecret.name}'

--- a/hub/resourcedescriptors/kubedb.com/v1/kafkas.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1/kafkas.yaml
@@ -34,6 +34,14 @@ spec:
       kind: AppBinding
     type: MatchName
   - labels:
+    - auth_secret
+    references:
+    - '{.spec.authSecret.name}'
+    target:
+      apiVersion: v1
+      kind: Secret
+    type: MatchRef
+  - labels:
     - catalog
     references:
     - '{.spec.version}'

--- a/hub/resourcedescriptors/kubedb.com/v1/mariadbs.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1/mariadbs.yaml
@@ -24,6 +24,16 @@ spec:
       kind: PetSet
     type: MatchSelector
   - labels:
+    - connect_via
+    level: Controller
+    nameTemplate: '{.metadata.name}'
+    namespace:
+      path: metadata.namespace
+    target:
+      apiVersion: appcatalog.appscode.com/v1alpha1
+      kind: AppBinding
+    type: MatchName
+  - labels:
     - auth_secret
     references:
     - '{.spec.authSecret.name}'

--- a/hub/resourcedescriptors/kubedb.com/v1/memcacheds.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1/memcacheds.yaml
@@ -34,6 +34,14 @@ spec:
       kind: AppBinding
     type: MatchName
   - labels:
+    - auth_secret
+    references:
+    - '{.spec.authSecret.name}'
+    target:
+      apiVersion: v1
+      kind: Secret
+    type: MatchRef
+  - labels:
     - catalog
     references:
     - '{.spec.version}'

--- a/hub/resourcedescriptors/kubedb.com/v1/mongodbs.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1/mongodbs.yaml
@@ -24,6 +24,16 @@ spec:
       kind: PetSet
     type: MatchSelector
   - labels:
+    - connect_via
+    level: Controller
+    nameTemplate: '{.metadata.name}'
+    namespace:
+      path: metadata.namespace
+    target:
+      apiVersion: appcatalog.appscode.com/v1alpha1
+      kind: AppBinding
+    type: MatchName
+  - labels:
     - auth_secret
     references:
     - '{.spec.authSecret.name}'

--- a/hub/resourcedescriptors/kubedb.com/v1/mysqls.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1/mysqls.yaml
@@ -24,6 +24,16 @@ spec:
       kind: PetSet
     type: MatchSelector
   - labels:
+    - connect_via
+    level: Controller
+    nameTemplate: '{.metadata.name}'
+    namespace:
+      path: metadata.namespace
+    target:
+      apiVersion: appcatalog.appscode.com/v1alpha1
+      kind: AppBinding
+    type: MatchName
+  - labels:
     - auth_secret
     references:
     - '{.spec.authSecret.name}'

--- a/hub/resourcedescriptors/kubedb.com/v1/perconaxtradbs.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1/perconaxtradbs.yaml
@@ -34,6 +34,14 @@ spec:
       kind: AppBinding
     type: MatchName
   - labels:
+    - auth_secret
+    references:
+    - '{.spec.authSecret.name}'
+    target:
+      apiVersion: v1
+      kind: Secret
+    type: MatchRef
+  - labels:
     - catalog
     references:
     - '{.spec.version}'

--- a/hub/resourcedescriptors/kubedb.com/v1/pgbouncers.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1/pgbouncers.yaml
@@ -34,6 +34,14 @@ spec:
       kind: AppBinding
     type: MatchName
   - labels:
+    - auth_secret
+    references:
+    - '{.spec.authSecret.name}'
+    target:
+      apiVersion: v1
+      kind: Secret
+    type: MatchRef
+  - labels:
     - catalog
     references:
     - '{.spec.version}'

--- a/hub/resourcedescriptors/kubedb.com/v1/postgreses.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1/postgreses.yaml
@@ -24,6 +24,16 @@ spec:
       kind: PetSet
     type: MatchSelector
   - labels:
+    - connect_via
+    level: Controller
+    nameTemplate: '{.metadata.name}'
+    namespace:
+      path: metadata.namespace
+    target:
+      apiVersion: appcatalog.appscode.com/v1alpha1
+      kind: AppBinding
+    type: MatchName
+  - labels:
     - auth_secret
     references:
     - '{.spec.authSecret.name}'

--- a/hub/resourcedescriptors/kubedb.com/v1/proxysqls.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1/proxysqls.yaml
@@ -34,6 +34,14 @@ spec:
       kind: AppBinding
     type: MatchName
   - labels:
+    - auth_secret
+    references:
+    - '{.spec.authSecret.name}'
+    target:
+      apiVersion: v1
+      kind: Secret
+    type: MatchRef
+  - labels:
     - catalog
     references:
     - '{.spec.version}'

--- a/hub/resourcedescriptors/kubedb.com/v1/redises.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1/redises.yaml
@@ -24,6 +24,16 @@ spec:
       kind: PetSet
     type: MatchSelector
   - labels:
+    - connect_via
+    level: Controller
+    nameTemplate: '{.metadata.name}'
+    namespace:
+      path: metadata.namespace
+    target:
+      apiVersion: appcatalog.appscode.com/v1alpha1
+      kind: AppBinding
+    type: MatchName
+  - labels:
     - auth_secret
     references:
     - '{.spec.authSecret.name}'

--- a/hub/resourcedescriptors/kubedb.com/v1/redissentinels.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1/redissentinels.yaml
@@ -34,6 +34,14 @@ spec:
       kind: AppBinding
     type: MatchName
   - labels:
+    - auth_secret
+    references:
+    - '{.spec.authSecret.name}'
+    target:
+      apiVersion: v1
+      kind: Secret
+    type: MatchRef
+  - labels:
     - catalog
     references:
     - '{.spec.version}'

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/aerospikes.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/aerospikes.yaml
@@ -34,6 +34,14 @@ spec:
       kind: AppBinding
     type: MatchName
   - labels:
+    - auth_secret
+    references:
+    - '{.spec.authSecret.name}'
+    target:
+      apiVersion: v1
+      kind: Secret
+    type: MatchRef
+  - labels:
     - catalog
     references:
     - '{.spec.version}'

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/cassandras.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/cassandras.yaml
@@ -34,6 +34,14 @@ spec:
       kind: AppBinding
     type: MatchName
   - labels:
+    - auth_secret
+    references:
+    - '{.spec.authSecret.name}'
+    target:
+      apiVersion: v1
+      kind: Secret
+    type: MatchRef
+  - labels:
     - catalog
     references:
     - '{.spec.version}'

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/clickhouses.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/clickhouses.yaml
@@ -34,6 +34,14 @@ spec:
       kind: AppBinding
     type: MatchName
   - labels:
+    - auth_secret
+    references:
+    - '{.spec.authSecret.name}'
+    target:
+      apiVersion: v1
+      kind: Secret
+    type: MatchRef
+  - labels:
     - catalog
     references:
     - '{.spec.version}'

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/db2s.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/db2s.yaml
@@ -34,6 +34,14 @@ spec:
       kind: AppBinding
     type: MatchName
   - labels:
+    - auth_secret
+    references:
+    - '{.spec.authSecret.name}'
+    target:
+      apiVersion: v1
+      kind: Secret
+    type: MatchRef
+  - labels:
     - catalog
     references:
     - '{.spec.version}'

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/documentdbs.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/documentdbs.yaml
@@ -34,12 +34,38 @@ spec:
       kind: AppBinding
     type: MatchName
   - labels:
+    - auth_secret
+    references:
+    - '{.spec.authSecret.name}'
+    target:
+      apiVersion: v1
+      kind: Secret
+    type: MatchRef
+  - labels:
     - catalog
     references:
     - '{.spec.version}'
     target:
       apiVersion: catalog.kubedb.com/v1alpha1
       kind: DocumentDBVersion
+    type: MatchRef
+  - labels:
+    - cert_issuer
+    namespace:
+      path: metadata.namespace
+    references:
+    - '{.spec.tls.issuerRef.name},{.metadata.namespace}'
+    target:
+      apiVersion: cert-manager.io/v1
+      kind: Issuer
+    type: MatchRef
+  - labels:
+    - cert_issuer
+    references:
+    - '{.spec.tls.issuerRef.name}'
+    target:
+      apiVersion: cert-manager.io/v1
+      kind: ClusterIssuer
     type: MatchRef
   - labels:
     - view

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/druids.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/druids.yaml
@@ -34,6 +34,14 @@ spec:
       kind: AppBinding
     type: MatchName
   - labels:
+    - auth_secret
+    references:
+    - '{.spec.authSecret.name}'
+    target:
+      apiVersion: v1
+      kind: Secret
+    type: MatchRef
+  - labels:
     - catalog
     references:
     - '{.spec.version}'

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/elasticsearches.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/elasticsearches.yaml
@@ -24,6 +24,16 @@ spec:
       kind: PetSet
     type: MatchSelector
   - labels:
+    - connect_via
+    level: Controller
+    nameTemplate: '{.metadata.name}'
+    namespace:
+      path: metadata.namespace
+    target:
+      apiVersion: appcatalog.appscode.com/v1alpha1
+      kind: AppBinding
+    type: MatchName
+  - labels:
     - auth_secret
     references:
     - '{.spec.authSecret.name}'

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/etcds.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/etcds.yaml
@@ -34,12 +34,38 @@ spec:
       kind: AppBinding
     type: MatchName
   - labels:
+    - auth_secret
+    references:
+    - '{.spec.authSecret.name}'
+    target:
+      apiVersion: v1
+      kind: Secret
+    type: MatchRef
+  - labels:
     - catalog
     references:
     - '{.spec.version}'
     target:
       apiVersion: catalog.kubedb.com/v1alpha1
       kind: EtcdVersion
+    type: MatchRef
+  - labels:
+    - cert_issuer
+    namespace:
+      path: metadata.namespace
+    references:
+    - '{.spec.tls.issuerRef.name},{.metadata.namespace}'
+    target:
+      apiVersion: cert-manager.io/v1
+      kind: Issuer
+    type: MatchRef
+  - labels:
+    - cert_issuer
+    references:
+    - '{.spec.tls.issuerRef.name}'
+    target:
+      apiVersion: cert-manager.io/v1
+      kind: ClusterIssuer
     type: MatchRef
   - labels:
     - view

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/hanadbs.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/hanadbs.yaml
@@ -34,6 +34,14 @@ spec:
       kind: AppBinding
     type: MatchName
   - labels:
+    - auth_secret
+    references:
+    - '{.spec.authSecret.name}'
+    target:
+      apiVersion: v1
+      kind: Secret
+    type: MatchRef
+  - labels:
     - catalog
     references:
     - '{.spec.version}'

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/hazelcasts.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/hazelcasts.yaml
@@ -34,6 +34,14 @@ spec:
       kind: AppBinding
     type: MatchName
   - labels:
+    - auth_secret
+    references:
+    - '{.spec.authSecret.name}'
+    target:
+      apiVersion: v1
+      kind: Secret
+    type: MatchRef
+  - labels:
     - catalog
     references:
     - '{.spec.version}'

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/ignites.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/ignites.yaml
@@ -34,6 +34,14 @@ spec:
       kind: AppBinding
     type: MatchName
   - labels:
+    - auth_secret
+    references:
+    - '{.spec.authSecret.name}'
+    target:
+      apiVersion: v1
+      kind: Secret
+    type: MatchRef
+  - labels:
     - catalog
     references:
     - '{.spec.version}'

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/kafkas.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/kafkas.yaml
@@ -34,6 +34,14 @@ spec:
       kind: AppBinding
     type: MatchName
   - labels:
+    - auth_secret
+    references:
+    - '{.spec.authSecret.name}'
+    target:
+      apiVersion: v1
+      kind: Secret
+    type: MatchRef
+  - labels:
     - catalog
     references:
     - '{.spec.version}'

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/mariadbs.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/mariadbs.yaml
@@ -24,6 +24,16 @@ spec:
       kind: PetSet
     type: MatchSelector
   - labels:
+    - connect_via
+    level: Controller
+    nameTemplate: '{.metadata.name}'
+    namespace:
+      path: metadata.namespace
+    target:
+      apiVersion: appcatalog.appscode.com/v1alpha1
+      kind: AppBinding
+    type: MatchName
+  - labels:
     - auth_secret
     references:
     - '{.spec.authSecret.name}'

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/memcacheds.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/memcacheds.yaml
@@ -68,6 +68,15 @@ spec:
       apiVersion: core.k8s.appscode.com/v1alpha1
       kind: GenericResource
     type: MatchName
+  - labels:
+    - view
+    nameTemplate: '{.metadata.name}~Memcached.kubedb.com'
+    namespace:
+      path: metadata.namespace
+    target:
+      apiVersion: core.k8s.appscode.com/v1alpha1
+      kind: GenericResourceService
+    type: MatchName
   exec:
   - alias: Primary
     command:

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/milvuses.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/milvuses.yaml
@@ -34,6 +34,14 @@ spec:
       kind: AppBinding
     type: MatchName
   - labels:
+    - auth_secret
+    references:
+    - '{.spec.authSecret.name}'
+    target:
+      apiVersion: v1
+      kind: Secret
+    type: MatchRef
+  - labels:
     - catalog
     references:
     - '{.spec.version}'

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/mongodbs.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/mongodbs.yaml
@@ -24,6 +24,16 @@ spec:
       kind: PetSet
     type: MatchSelector
   - labels:
+    - connect_via
+    level: Controller
+    nameTemplate: '{.metadata.name}'
+    namespace:
+      path: metadata.namespace
+    target:
+      apiVersion: appcatalog.appscode.com/v1alpha1
+      kind: AppBinding
+    type: MatchName
+  - labels:
     - auth_secret
     references:
     - '{.spec.authSecret.name}'

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/mssqlservers.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/mssqlservers.yaml
@@ -34,6 +34,14 @@ spec:
       kind: AppBinding
     type: MatchName
   - labels:
+    - auth_secret
+    references:
+    - '{.spec.authSecret.name}'
+    target:
+      apiVersion: v1
+      kind: Secret
+    type: MatchRef
+  - labels:
     - catalog
     references:
     - '{.spec.version}'

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/mysqls.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/mysqls.yaml
@@ -24,6 +24,16 @@ spec:
       kind: PetSet
     type: MatchSelector
   - labels:
+    - connect_via
+    level: Controller
+    nameTemplate: '{.metadata.name}'
+    namespace:
+      path: metadata.namespace
+    target:
+      apiVersion: appcatalog.appscode.com/v1alpha1
+      kind: AppBinding
+    type: MatchName
+  - labels:
     - auth_secret
     references:
     - '{.spec.authSecret.name}'

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/neo4js.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/neo4js.yaml
@@ -34,6 +34,14 @@ spec:
       kind: AppBinding
     type: MatchName
   - labels:
+    - auth_secret
+    references:
+    - '{.spec.authSecret.name}'
+    target:
+      apiVersion: v1
+      kind: Secret
+    type: MatchRef
+  - labels:
     - catalog
     references:
     - '{.spec.version}'

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/oracles.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/oracles.yaml
@@ -34,6 +34,14 @@ spec:
       kind: AppBinding
     type: MatchName
   - labels:
+    - auth_secret
+    references:
+    - '{.spec.authSecret.name}'
+    target:
+      apiVersion: v1
+      kind: Secret
+    type: MatchRef
+  - labels:
     - catalog
     references:
     - '{.spec.version}'

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/perconaxtradbs.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/perconaxtradbs.yaml
@@ -34,6 +34,14 @@ spec:
       kind: AppBinding
     type: MatchName
   - labels:
+    - auth_secret
+    references:
+    - '{.spec.authSecret.name}'
+    target:
+      apiVersion: v1
+      kind: Secret
+    type: MatchRef
+  - labels:
     - catalog
     references:
     - '{.spec.version}'
@@ -59,6 +67,24 @@ spec:
       apiVersion: cert-manager.io/v1
       kind: ClusterIssuer
     type: MatchRef
+  - labels:
+    - view
+    nameTemplate: '{.metadata.name}~PerconaXtraDB.kubedb.com'
+    namespace:
+      path: metadata.namespace
+    target:
+      apiVersion: core.k8s.appscode.com/v1alpha1
+      kind: GenericResource
+    type: MatchName
+  - labels:
+    - view
+    nameTemplate: '{.metadata.name}~PerconaXtraDB.kubedb.com'
+    namespace:
+      path: metadata.namespace
+    target:
+      apiVersion: core.k8s.appscode.com/v1alpha1
+      kind: GenericResourceService
+    type: MatchName
   exec:
   - alias: Primary
     command:

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/pgbouncers.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/pgbouncers.yaml
@@ -34,6 +34,14 @@ spec:
       kind: AppBinding
     type: MatchName
   - labels:
+    - auth_secret
+    references:
+    - '{.spec.authSecret.name}'
+    target:
+      apiVersion: v1
+      kind: Secret
+    type: MatchRef
+  - labels:
     - catalog
     references:
     - '{.spec.version}'
@@ -59,6 +67,24 @@ spec:
       apiVersion: cert-manager.io/v1
       kind: ClusterIssuer
     type: MatchRef
+  - labels:
+    - view
+    nameTemplate: '{.metadata.name}~PgBouncer.kubedb.com'
+    namespace:
+      path: metadata.namespace
+    target:
+      apiVersion: core.k8s.appscode.com/v1alpha1
+      kind: GenericResource
+    type: MatchName
+  - labels:
+    - view
+    nameTemplate: '{.metadata.name}~PgBouncer.kubedb.com'
+    namespace:
+      path: metadata.namespace
+    target:
+      apiVersion: core.k8s.appscode.com/v1alpha1
+      kind: GenericResourceService
+    type: MatchName
   resource:
     group: kubedb.com
     kind: PgBouncer

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/pgpools.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/pgpools.yaml
@@ -34,6 +34,14 @@ spec:
       kind: AppBinding
     type: MatchName
   - labels:
+    - auth_secret
+    references:
+    - '{.spec.authSecret.name}'
+    target:
+      apiVersion: v1
+      kind: Secret
+    type: MatchRef
+  - labels:
     - catalog
     references:
     - '{.spec.version}'

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/postgreses.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/postgreses.yaml
@@ -24,6 +24,16 @@ spec:
       kind: PetSet
     type: MatchSelector
   - labels:
+    - connect_via
+    level: Controller
+    nameTemplate: '{.metadata.name}'
+    namespace:
+      path: metadata.namespace
+    target:
+      apiVersion: appcatalog.appscode.com/v1alpha1
+      kind: AppBinding
+    type: MatchName
+  - labels:
     - auth_secret
     references:
     - '{.spec.authSecret.name}'

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/proxysqls.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/proxysqls.yaml
@@ -34,6 +34,14 @@ spec:
       kind: AppBinding
     type: MatchName
   - labels:
+    - auth_secret
+    references:
+    - '{.spec.authSecret.name}'
+    target:
+      apiVersion: v1
+      kind: Secret
+    type: MatchRef
+  - labels:
     - catalog
     references:
     - '{.spec.version}'

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/qdrants.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/qdrants.yaml
@@ -34,6 +34,14 @@ spec:
       kind: AppBinding
     type: MatchName
   - labels:
+    - auth_secret
+    references:
+    - '{.spec.authSecret.name}'
+    target:
+      apiVersion: v1
+      kind: Secret
+    type: MatchRef
+  - labels:
     - catalog
     references:
     - '{.spec.version}'

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/rabbitmqs.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/rabbitmqs.yaml
@@ -34,6 +34,14 @@ spec:
       kind: AppBinding
     type: MatchName
   - labels:
+    - auth_secret
+    references:
+    - '{.spec.authSecret.name}'
+    target:
+      apiVersion: v1
+      kind: Secret
+    type: MatchRef
+  - labels:
     - catalog
     references:
     - '{.spec.version}'

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/redises.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/redises.yaml
@@ -24,6 +24,16 @@ spec:
       kind: PetSet
     type: MatchSelector
   - labels:
+    - connect_via
+    level: Controller
+    nameTemplate: '{.metadata.name}'
+    namespace:
+      path: metadata.namespace
+    target:
+      apiVersion: appcatalog.appscode.com/v1alpha1
+      kind: AppBinding
+    type: MatchName
+  - labels:
     - auth_secret
     references:
     - '{.spec.authSecret.name}'

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/redissentinels.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/redissentinels.yaml
@@ -34,6 +34,14 @@ spec:
       kind: AppBinding
     type: MatchName
   - labels:
+    - auth_secret
+    references:
+    - '{.spec.authSecret.name}'
+    target:
+      apiVersion: v1
+      kind: Secret
+    type: MatchRef
+  - labels:
     - catalog
     references:
     - '{.spec.version}'

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/singlestores.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/singlestores.yaml
@@ -34,6 +34,14 @@ spec:
       kind: AppBinding
     type: MatchName
   - labels:
+    - auth_secret
+    references:
+    - '{.spec.authSecret.name}'
+    target:
+      apiVersion: v1
+      kind: Secret
+    type: MatchRef
+  - labels:
     - catalog
     references:
     - '{.spec.version}'

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/solrs.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/solrs.yaml
@@ -34,6 +34,14 @@ spec:
       kind: AppBinding
     type: MatchName
   - labels:
+    - auth_secret
+    references:
+    - '{.spec.authSecret.name}'
+    target:
+      apiVersion: v1
+      kind: Secret
+    type: MatchRef
+  - labels:
     - catalog
     references:
     - '{.spec.version}'

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/weaviates.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/weaviates.yaml
@@ -34,6 +34,14 @@ spec:
       kind: AppBinding
     type: MatchName
   - labels:
+    - auth_secret
+    references:
+    - '{.spec.authSecret.name}'
+    target:
+      apiVersion: v1
+      kind: Secret
+    type: MatchRef
+  - labels:
     - catalog
     references:
     - '{.spec.version}'

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/zookeepers.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/zookeepers.yaml
@@ -34,6 +34,14 @@ spec:
       kind: AppBinding
     type: MatchName
   - labels:
+    - auth_secret
+    references:
+    - '{.spec.authSecret.name}'
+    target:
+      apiVersion: v1
+      kind: Secret
+    type: MatchRef
+  - labels:
     - catalog
     references:
     - '{.spec.version}'

--- a/hub/resourcedescriptors/supervisor.appscode.com/v1alpha1/recommendations.yaml
+++ b/hub/resourcedescriptors/supervisor.appscode.com/v1alpha1/recommendations.yaml
@@ -17,6 +17,106 @@ spec:
     - '{.spec.target.name},{.metadata.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
     target:
       apiVersion: kubedb.com/v1alpha2
+      kind: Aerospike
+    type: MatchRef
+  - labels:
+    - ops
+    namespace:
+      path: metadata.namespace
+    references:
+    - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
+    target:
+      apiVersion: kubedb.com/v1alpha1
+      kind: AerospikeOpsRequest
+    type: MatchRef
+  - labels:
+    - recommended_for
+    namespace:
+      path: metadata.namespace
+    references:
+    - '{.spec.target.name},{.metadata.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: Cassandra
+    type: MatchRef
+  - labels:
+    - ops
+    namespace:
+      path: metadata.namespace
+    references:
+    - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
+    target:
+      apiVersion: kubedb.com/v1alpha1
+      kind: CassandraOpsRequest
+    type: MatchRef
+  - labels:
+    - recommended_for
+    namespace:
+      path: metadata.namespace
+    references:
+    - '{.spec.target.name},{.metadata.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: ClickHouse
+    type: MatchRef
+  - labels:
+    - ops
+    namespace:
+      path: metadata.namespace
+    references:
+    - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
+    target:
+      apiVersion: kubedb.com/v1alpha1
+      kind: ClickHouseOpsRequest
+    type: MatchRef
+  - labels:
+    - recommended_for
+    namespace:
+      path: metadata.namespace
+    references:
+    - '{.spec.target.name},{.metadata.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: DB2
+    type: MatchRef
+  - labels:
+    - ops
+    namespace:
+      path: metadata.namespace
+    references:
+    - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
+    target:
+      apiVersion: kubedb.com/v1alpha1
+      kind: DB2OpsRequest
+    type: MatchRef
+  - labels:
+    - recommended_for
+    namespace:
+      path: metadata.namespace
+    references:
+    - '{.spec.target.name},{.metadata.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: DocumentDB
+    type: MatchRef
+  - labels:
+    - ops
+    namespace:
+      path: metadata.namespace
+    references:
+    - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
+    target:
+      apiVersion: kubedb.com/v1alpha1
+      kind: DocumentDBOpsRequest
+    type: MatchRef
+  - labels:
+    - recommended_for
+    namespace:
+      path: metadata.namespace
+    references:
+    - '{.spec.target.name},{.metadata.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
       kind: Druid
     type: MatchRef
   - labels:
@@ -48,6 +148,66 @@ spec:
     target:
       apiVersion: kubedb.com/v1alpha1
       kind: ElasticsearchOpsRequest
+    type: MatchRef
+  - labels:
+    - recommended_for
+    namespace:
+      path: metadata.namespace
+    references:
+    - '{.spec.target.name},{.metadata.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: HanaDB
+    type: MatchRef
+  - labels:
+    - ops
+    namespace:
+      path: metadata.namespace
+    references:
+    - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
+    target:
+      apiVersion: kubedb.com/v1alpha1
+      kind: HanaDBOpsRequest
+    type: MatchRef
+  - labels:
+    - recommended_for
+    namespace:
+      path: metadata.namespace
+    references:
+    - '{.spec.target.name},{.metadata.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: Hazelcast
+    type: MatchRef
+  - labels:
+    - ops
+    namespace:
+      path: metadata.namespace
+    references:
+    - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
+    target:
+      apiVersion: kubedb.com/v1alpha1
+      kind: HazelcastOpsRequest
+    type: MatchRef
+  - labels:
+    - recommended_for
+    namespace:
+      path: metadata.namespace
+    references:
+    - '{.spec.target.name},{.metadata.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: Ignite
+    type: MatchRef
+  - labels:
+    - ops
+    namespace:
+      path: metadata.namespace
+    references:
+    - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
+    target:
+      apiVersion: kubedb.com/v1alpha1
+      kind: IgniteOpsRequest
     type: MatchRef
   - labels:
     - recommended_for
@@ -116,6 +276,26 @@ spec:
     references:
     - '{.spec.target.name},{.metadata.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
     target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: Milvus
+    type: MatchRef
+  - labels:
+    - ops
+    namespace:
+      path: metadata.namespace
+    references:
+    - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
+    target:
+      apiVersion: kubedb.com/v1alpha1
+      kind: MilvusOpsRequest
+    type: MatchRef
+  - labels:
+    - recommended_for
+    namespace:
+      path: metadata.namespace
+    references:
+    - '{.spec.target.name},{.metadata.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
       apiVersion: kubedb.com/v1
       kind: MongoDB
     type: MatchRef
@@ -168,6 +348,46 @@ spec:
     target:
       apiVersion: kubedb.com/v1alpha1
       kind: MySQLOpsRequest
+    type: MatchRef
+  - labels:
+    - recommended_for
+    namespace:
+      path: metadata.namespace
+    references:
+    - '{.spec.target.name},{.metadata.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: Neo4j
+    type: MatchRef
+  - labels:
+    - ops
+    namespace:
+      path: metadata.namespace
+    references:
+    - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
+    target:
+      apiVersion: kubedb.com/v1alpha1
+      kind: Neo4jOpsRequest
+    type: MatchRef
+  - labels:
+    - recommended_for
+    namespace:
+      path: metadata.namespace
+    references:
+    - '{.spec.target.name},{.metadata.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: Oracle
+    type: MatchRef
+  - labels:
+    - ops
+    namespace:
+      path: metadata.namespace
+    references:
+    - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
+    target:
+      apiVersion: kubedb.com/v1alpha1
+      kind: OracleOpsRequest
     type: MatchRef
   - labels:
     - recommended_for
@@ -277,6 +497,26 @@ spec:
     - '{.spec.target.name},{.metadata.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
     target:
       apiVersion: kubedb.com/v1alpha2
+      kind: Qdrant
+    type: MatchRef
+  - labels:
+    - ops
+    namespace:
+      path: metadata.namespace
+    references:
+    - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
+    target:
+      apiVersion: kubedb.com/v1alpha1
+      kind: QdrantOpsRequest
+    type: MatchRef
+  - labels:
+    - recommended_for
+    namespace:
+      path: metadata.namespace
+    references:
+    - '{.spec.target.name},{.metadata.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
       kind: RabbitMQ
     type: MatchRef
   - labels:
@@ -348,6 +588,26 @@ spec:
     target:
       apiVersion: kubedb.com/v1alpha1
       kind: SolrOpsRequest
+    type: MatchRef
+  - labels:
+    - recommended_for
+    namespace:
+      path: metadata.namespace
+    references:
+    - '{.spec.target.name},{.metadata.namespace},{.spec.target.kind},{.spec.target.apiGroup}'
+    target:
+      apiVersion: kubedb.com/v1alpha2
+      kind: Weaviate
+    type: MatchRef
+  - labels:
+    - ops
+    namespace:
+      path: metadata.namespace
+    references:
+    - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
+    target:
+      apiVersion: kubedb.com/v1alpha1
+      kind: WeaviateOpsRequest
     type: MatchRef
   - labels:
     - recommended_for

--- a/hub/resourcedescriptors/supervisor.appscode.com/v1alpha1/recommendations.yaml
+++ b/hub/resourcedescriptors/supervisor.appscode.com/v1alpha1/recommendations.yaml
@@ -26,7 +26,7 @@ spec:
     references:
     - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
     target:
-      apiVersion: kubedb.com/v1alpha1
+      apiVersion: ops.kubedb.com/v1alpha1
       kind: AerospikeOpsRequest
     type: MatchRef
   - labels:
@@ -46,7 +46,7 @@ spec:
     references:
     - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
     target:
-      apiVersion: kubedb.com/v1alpha1
+      apiVersion: ops.kubedb.com/v1alpha1
       kind: CassandraOpsRequest
     type: MatchRef
   - labels:
@@ -66,7 +66,7 @@ spec:
     references:
     - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
     target:
-      apiVersion: kubedb.com/v1alpha1
+      apiVersion: ops.kubedb.com/v1alpha1
       kind: ClickHouseOpsRequest
     type: MatchRef
   - labels:
@@ -86,7 +86,7 @@ spec:
     references:
     - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
     target:
-      apiVersion: kubedb.com/v1alpha1
+      apiVersion: ops.kubedb.com/v1alpha1
       kind: DB2OpsRequest
     type: MatchRef
   - labels:
@@ -106,7 +106,7 @@ spec:
     references:
     - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
     target:
-      apiVersion: kubedb.com/v1alpha1
+      apiVersion: ops.kubedb.com/v1alpha1
       kind: DocumentDBOpsRequest
     type: MatchRef
   - labels:
@@ -126,7 +126,7 @@ spec:
     references:
     - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
     target:
-      apiVersion: kubedb.com/v1alpha1
+      apiVersion: ops.kubedb.com/v1alpha1
       kind: DruidOpsRequest
     type: MatchRef
   - labels:
@@ -146,7 +146,7 @@ spec:
     references:
     - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
     target:
-      apiVersion: kubedb.com/v1alpha1
+      apiVersion: ops.kubedb.com/v1alpha1
       kind: ElasticsearchOpsRequest
     type: MatchRef
   - labels:
@@ -166,7 +166,7 @@ spec:
     references:
     - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
     target:
-      apiVersion: kubedb.com/v1alpha1
+      apiVersion: ops.kubedb.com/v1alpha1
       kind: HanaDBOpsRequest
     type: MatchRef
   - labels:
@@ -186,7 +186,7 @@ spec:
     references:
     - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
     target:
-      apiVersion: kubedb.com/v1alpha1
+      apiVersion: ops.kubedb.com/v1alpha1
       kind: HazelcastOpsRequest
     type: MatchRef
   - labels:
@@ -206,7 +206,7 @@ spec:
     references:
     - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
     target:
-      apiVersion: kubedb.com/v1alpha1
+      apiVersion: ops.kubedb.com/v1alpha1
       kind: IgniteOpsRequest
     type: MatchRef
   - labels:
@@ -226,7 +226,7 @@ spec:
     references:
     - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
     target:
-      apiVersion: kubedb.com/v1alpha1
+      apiVersion: ops.kubedb.com/v1alpha1
       kind: KafkaOpsRequest
     type: MatchRef
   - labels:
@@ -246,7 +246,7 @@ spec:
     references:
     - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
     target:
-      apiVersion: kubedb.com/v1alpha1
+      apiVersion: ops.kubedb.com/v1alpha1
       kind: MariaDBOpsRequest
     type: MatchRef
   - labels:
@@ -266,7 +266,7 @@ spec:
     references:
     - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
     target:
-      apiVersion: kubedb.com/v1alpha1
+      apiVersion: ops.kubedb.com/v1alpha1
       kind: MemcachedOpsRequest
     type: MatchRef
   - labels:
@@ -286,7 +286,7 @@ spec:
     references:
     - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
     target:
-      apiVersion: kubedb.com/v1alpha1
+      apiVersion: ops.kubedb.com/v1alpha1
       kind: MilvusOpsRequest
     type: MatchRef
   - labels:
@@ -306,7 +306,7 @@ spec:
     references:
     - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
     target:
-      apiVersion: kubedb.com/v1alpha1
+      apiVersion: ops.kubedb.com/v1alpha1
       kind: MongoDBOpsRequest
     type: MatchRef
   - labels:
@@ -326,7 +326,7 @@ spec:
     references:
     - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
     target:
-      apiVersion: kubedb.com/v1alpha1
+      apiVersion: ops.kubedb.com/v1alpha1
       kind: MSSQLServerOpsRequest
     type: MatchRef
   - labels:
@@ -346,7 +346,7 @@ spec:
     references:
     - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
     target:
-      apiVersion: kubedb.com/v1alpha1
+      apiVersion: ops.kubedb.com/v1alpha1
       kind: MySQLOpsRequest
     type: MatchRef
   - labels:
@@ -366,7 +366,7 @@ spec:
     references:
     - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
     target:
-      apiVersion: kubedb.com/v1alpha1
+      apiVersion: ops.kubedb.com/v1alpha1
       kind: Neo4jOpsRequest
     type: MatchRef
   - labels:
@@ -386,7 +386,7 @@ spec:
     references:
     - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
     target:
-      apiVersion: kubedb.com/v1alpha1
+      apiVersion: ops.kubedb.com/v1alpha1
       kind: OracleOpsRequest
     type: MatchRef
   - labels:
@@ -406,7 +406,7 @@ spec:
     references:
     - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
     target:
-      apiVersion: kubedb.com/v1alpha1
+      apiVersion: ops.kubedb.com/v1alpha1
       kind: PerconaXtraDBOpsRequest
     type: MatchRef
   - labels:
@@ -426,7 +426,7 @@ spec:
     references:
     - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
     target:
-      apiVersion: kubedb.com/v1alpha1
+      apiVersion: ops.kubedb.com/v1alpha1
       kind: PgBouncerOpsRequest
     type: MatchRef
   - labels:
@@ -446,7 +446,7 @@ spec:
     references:
     - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
     target:
-      apiVersion: kubedb.com/v1alpha1
+      apiVersion: ops.kubedb.com/v1alpha1
       kind: PgpoolOpsRequest
     type: MatchRef
   - labels:
@@ -466,7 +466,7 @@ spec:
     references:
     - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
     target:
-      apiVersion: kubedb.com/v1alpha1
+      apiVersion: ops.kubedb.com/v1alpha1
       kind: PostgresOpsRequest
     type: MatchRef
   - labels:
@@ -486,7 +486,7 @@ spec:
     references:
     - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
     target:
-      apiVersion: kubedb.com/v1alpha1
+      apiVersion: ops.kubedb.com/v1alpha1
       kind: ProxySQLOpsRequest
     type: MatchRef
   - labels:
@@ -506,7 +506,7 @@ spec:
     references:
     - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
     target:
-      apiVersion: kubedb.com/v1alpha1
+      apiVersion: ops.kubedb.com/v1alpha1
       kind: QdrantOpsRequest
     type: MatchRef
   - labels:
@@ -526,7 +526,7 @@ spec:
     references:
     - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
     target:
-      apiVersion: kubedb.com/v1alpha1
+      apiVersion: ops.kubedb.com/v1alpha1
       kind: RabbitMQOpsRequest
     type: MatchRef
   - labels:
@@ -546,7 +546,7 @@ spec:
     references:
     - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
     target:
-      apiVersion: kubedb.com/v1alpha1
+      apiVersion: ops.kubedb.com/v1alpha1
       kind: RedisOpsRequest
     type: MatchRef
   - labels:
@@ -566,7 +566,7 @@ spec:
     references:
     - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
     target:
-      apiVersion: kubedb.com/v1alpha1
+      apiVersion: ops.kubedb.com/v1alpha1
       kind: SinglestoreOpsRequest
     type: MatchRef
   - labels:
@@ -586,7 +586,7 @@ spec:
     references:
     - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
     target:
-      apiVersion: kubedb.com/v1alpha1
+      apiVersion: ops.kubedb.com/v1alpha1
       kind: SolrOpsRequest
     type: MatchRef
   - labels:
@@ -606,7 +606,7 @@ spec:
     references:
     - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
     target:
-      apiVersion: kubedb.com/v1alpha1
+      apiVersion: ops.kubedb.com/v1alpha1
       kind: WeaviateOpsRequest
     type: MatchRef
   - labels:
@@ -626,7 +626,7 @@ spec:
     references:
     - '{.spec.operation.metadata.name},{.spec.operation.metadata.namespace},{.spec.operation.kind},{.spec.operation.apiVersion}'
     target:
-      apiVersion: kubedb.com/v1alpha1
+      apiVersion: ops.kubedb.com/v1alpha1
       kind: ZooKeeperOpsRequest
     type: MatchRef
   resource:


### PR DESCRIPTION
## What

Two related cleanups to `spec.connections` in the hub.

### 1. Connection parity across kubedb.com v1 + v1alpha2

Every ResourceDescriptor under `hub/resourcedescriptors/kubedb.com/{v1,v1alpha2}` (45 files) now carries the same 8 edges, with kind/name substituted per resource:

| label | target |
|---|---|
| `offshoot` | `apps.k8s.appscode.com/v1` PetSet |
| `connect_via` | `appcatalog.appscode.com/v1alpha1` AppBinding |
| `auth_secret` | `v1` Secret |
| `catalog` | `catalog.kubedb.com/v1alpha1` `<Kind>Version` |
| `cert_issuer` | `cert-manager.io/v1` Issuer + ClusterIssuer |
| `view` | `core.k8s.appscode.com/v1alpha1` GenericResource + GenericResourceService |

53 edges added: `auth_secret` x33, `connect_via` x12, `view` x5, `cert_issuer` x4.

**Deliberately excluded** where the JSONPath would reference a field absent from the resource's own schema:

- `auth_secret` not added to `v1alpha2/memcacheds.yaml` — no `spec.authSecret` (v1 Memcached has it, so v1 gets the edge)
- `cert_issuer` not added to `v1alpha2/db2s.yaml` — no `spec.tls`

DocumentDB and Oracle do get `cert_issuer` despite lacking `spec.tls` today, since the field is landing shortly.

### 2. Database coverage in recommendation / backup RDs

`supervisor.appscode.com` Recommendation, and `core.kubestash.com` BackupConfiguration + RestoreSession, were each missing most of the newer databases. All three now cover the same 31 databases:

- **v1**: elasticsearch, kafka, mariadb, memcached, mongodb, mysql, percona-xtradb, pgbouncer, postgres, proxysql, redis
- **v1alpha2**: aerospike, cassandra, clickhouse, db2, documentdb, druid, hanadb, hazelcast, ignite, milvus, mssqlserver, neo4j, oracle, pgpool, qdrant, rabbitmq, singlestore, solr, weaviate, zookeeper

## Notes for review

- **The `ops` blocks in recommendations.yaml target `apiVersion: kubedb.com/v1alpha1`, but the OpsRequest kinds live in group `ops.kubedb.com`.** This is pre-existing and uniform across all 18 original blocks (dating to #531), and recommendations.yaml is the only place in the hub referencing `*OpsRequest` targets. The 13 new pairs follow the existing convention rather than diverging. If it is a bug it should be fixed for all 31 in a separate commit — I did not trace how `MatchRef` resolves a mismatched group.
- PgBouncer, ProxySQL and Memcached are included as backup/restore targets because they were in the requested list; flagging in case a pooler/cache is not actually a KubeStash target.
- `auth_secret` blocks carry no `namespace` field, matching the existing MongoDB/Kafka convention.

## Verification

- `go run ./cmd/resource-fmt` — no output, inserted blocks already canonical
- `go run ./cmd/check-edge-label` — pass
- `go run ./cmd/check-query` — pass
- `go build ./...` — pass
- 1069 insertions, **0 deletions** — no existing entry modified or reordered

Not run: `make fmt` (Docker daemon unavailable locally; only YAML changed, so the gofmt/license passes are no-ops and the two domain-specific passes were run natively as above). `check-table` needs a live cluster. `check-schema` fails, but identically on a clean tree — pre-existing and unrelated.