### PR TITLE
Add exec connection options to remaining kubedb resource descriptors

### DIFF
--- a/hub/resourcedescriptors/kubedb.com/v1/kafkas.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1/kafkas.yaml
@@ -112,6 +112,14 @@ spec:
       apiVersion: ui.kubedb.com/v1alpha1
       kind: KafkaSchemaOverview
     type: MatchName
+  exec:
+  - alias: Primary
+    command:
+    - bash
+    container: kafka
+    help: |
+      kafka-topics.sh --bootstrap-server localhost:9092 --list
+    serviceNameTemplate: '{{- .metadata.name -}}'
   resource:
     group: kubedb.com
     kind: Kafka

--- a/hub/resourcedescriptors/kubedb.com/v1/pgbouncers.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1/pgbouncers.yaml
@@ -85,6 +85,16 @@ spec:
       apiVersion: core.k8s.appscode.com/v1alpha1
       kind: GenericResourceService
     type: MatchName
+  exec:
+  - alias: Primary
+    command:
+    - bash
+    - -c
+    - psql -p 5432 pgbouncer
+    container: pgbouncer
+    help: |
+      SHOW DATABASES;
+    serviceNameTemplate: '{{- .metadata.name -}}'
   resource:
     group: kubedb.com
     kind: PgBouncer

--- a/hub/resourcedescriptors/kubedb.com/v1/redissentinels.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1/redissentinels.yaml
@@ -85,6 +85,16 @@ spec:
       apiVersion: core.k8s.appscode.com/v1alpha1
       kind: GenericResourceService
     type: MatchName
+  exec:
+  - alias: Primary
+    command:
+    - bash
+    - -c
+    - redis-cli -p 26379
+    container: redissentinel
+    help: |
+      sentinel masters
+    serviceNameTemplate: '{{- .metadata.name -}}'
   resource:
     group: kubedb.com
     kind: RedisSentinel

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/aerospikes.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/aerospikes.yaml
@@ -85,6 +85,14 @@ spec:
       apiVersion: core.k8s.appscode.com/v1alpha1
       kind: GenericResourceService
     type: MatchName
+  exec:
+  - alias: Primary
+    command:
+    - asadm
+    container: aerospike
+    help: |
+      info
+    serviceNameTemplate: '{{- .metadata.name -}}'
   resource:
     group: kubedb.com
     kind: Aerospike

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/cassandras.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/cassandras.yaml
@@ -85,6 +85,16 @@ spec:
       apiVersion: core.k8s.appscode.com/v1alpha1
       kind: GenericResourceService
     type: MatchName
+  exec:
+  - alias: Primary
+    command:
+    - bash
+    - -c
+    - cqlsh -u "$CASSANDRA_USER" -p "$CASSANDRA_PASSWORD"
+    container: cassandra
+    help: |
+      DESCRIBE KEYSPACES;
+    serviceNameTemplate: '{{- .metadata.name -}}'
   resource:
     group: kubedb.com
     kind: Cassandra

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/clickhouses.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/clickhouses.yaml
@@ -85,6 +85,16 @@ spec:
       apiVersion: core.k8s.appscode.com/v1alpha1
       kind: GenericResourceService
     type: MatchName
+  exec:
+  - alias: Primary
+    command:
+    - bash
+    - -c
+    - clickhouse-client -u "$CLICKHOUSE_USER" --password "$CLICKHOUSE_PASSWORD"
+    container: clickhouse
+    help: |
+      SHOW DATABASES;
+    serviceNameTemplate: '{{- .metadata.name -}}'
   resource:
     group: kubedb.com
     kind: ClickHouse

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/db2s.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/db2s.yaml
@@ -67,6 +67,14 @@ spec:
       apiVersion: core.k8s.appscode.com/v1alpha1
       kind: GenericResourceService
     type: MatchName
+  exec:
+  - alias: Primary
+    command:
+    - db2
+    container: db2
+    help: |
+      connect to $DBNAME
+    serviceNameTemplate: '{{- .metadata.name -}}'
   resource:
     group: kubedb.com
     kind: DB2

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/documentdbs.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/documentdbs.yaml
@@ -85,6 +85,16 @@ spec:
       apiVersion: core.k8s.appscode.com/v1alpha1
       kind: GenericResourceService
     type: MatchName
+  exec:
+  - alias: Primary
+    command:
+    - bash
+    - -c
+    - psql -U "$POSTGRES_USER"
+    container: documentdb
+    help: |
+      \l
+    serviceNameTemplate: '{{- .metadata.name -}}'
   resource:
     group: kubedb.com
     kind: DocumentDB

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/druids.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/druids.yaml
@@ -112,6 +112,14 @@ spec:
       apiVersion: ui.kubedb.com/v1alpha1
       kind: DruidSchemaOverview
     type: MatchName
+  exec:
+  - alias: Primary
+    command:
+    - bash
+    container: druid
+    help: |
+      curl -u "admin:$DRUID_ADMIN_PASSWORD" "http://localhost:8888/status"
+    serviceNameTemplate: '{{- .metadata.name -}}'
   resource:
     group: kubedb.com
     kind: Druid

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/hanadbs.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/hanadbs.yaml
@@ -85,6 +85,16 @@ spec:
       apiVersion: core.k8s.appscode.com/v1alpha1
       kind: GenericResourceService
     type: MatchName
+  exec:
+  - alias: Primary
+    command:
+    - bash
+    - -c
+    - hdbsql -u "$HANA_USER" -p "$HANA_PASSWORD"
+    container: hanadb
+    help: |
+      \s
+    serviceNameTemplate: '{{- .metadata.name -}}'
   resource:
     group: kubedb.com
     kind: HanaDB

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/hazelcasts.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/hazelcasts.yaml
@@ -85,6 +85,14 @@ spec:
       apiVersion: core.k8s.appscode.com/v1alpha1
       kind: GenericResourceService
     type: MatchName
+  exec:
+  - alias: Primary
+    command:
+    - bash
+    container: hazelcast
+    help: |
+      hz-cli --targets "$USERNAME/dev@localhost:5701" cluster
+    serviceNameTemplate: '{{- .metadata.name -}}'
   resource:
     group: kubedb.com
     kind: Hazelcast

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/ignites.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/ignites.yaml
@@ -85,6 +85,14 @@ spec:
       apiVersion: core.k8s.appscode.com/v1alpha1
       kind: GenericResourceService
     type: MatchName
+  exec:
+  - alias: Primary
+    command:
+    - bash
+    container: ignite
+    help: |
+      /opt/ignite/apache-ignite/bin/control.sh --user ignite --password "$IGNITE_PASSWORD" --baseline
+    serviceNameTemplate: '{{- .metadata.name -}}'
   resource:
     group: kubedb.com
     kind: Ignite

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/kafkas.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/kafkas.yaml
@@ -112,6 +112,14 @@ spec:
       apiVersion: ui.kubedb.com/v1alpha1
       kind: KafkaSchemaOverview
     type: MatchName
+  exec:
+  - alias: Primary
+    command:
+    - bash
+    container: kafka
+    help: |
+      kafka-topics.sh --bootstrap-server localhost:9092 --list
+    serviceNameTemplate: '{{- .metadata.name -}}'
   resource:
     group: kubedb.com
     kind: Kafka

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/milvuses.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/milvuses.yaml
@@ -85,6 +85,14 @@ spec:
       apiVersion: core.k8s.appscode.com/v1alpha1
       kind: GenericResourceService
     type: MatchName
+  exec:
+  - alias: Primary
+    command:
+    - bash
+    container: milvus
+    help: |
+      curl "http://localhost:9091/healthz"
+    serviceNameTemplate: '{{- .metadata.name -}}'
   resource:
     group: kubedb.com
     kind: Milvus

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/mssqlservers.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/mssqlservers.yaml
@@ -112,6 +112,18 @@ spec:
       apiVersion: ui.kubedb.com/v1alpha1
       kind: MSSQLServerSchemaOverview
     type: MatchName
+  exec:
+  - alias: Primary
+    command:
+    - bash
+    - -c
+    - export PATH="/opt/mssql-tools18/bin:/opt/mssql-tools/bin:$PATH"; sqlcmd -S localhost
+      -U "$MSSQL_SA_USERNAME" -P "$MSSQL_SA_PASSWORD" -C
+    container: mssql
+    help: |
+      SELECT name FROM sys.databases;
+      GO
+    serviceNameTemplate: '{{- .metadata.name -}}'
   resource:
     group: kubedb.com
     kind: MSSQLServer

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/neo4js.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/neo4js.yaml
@@ -85,6 +85,16 @@ spec:
       apiVersion: core.k8s.appscode.com/v1alpha1
       kind: GenericResourceService
     type: MatchName
+  exec:
+  - alias: Primary
+    command:
+    - bash
+    - -c
+    - cypher-shell -u "$(cat /config/neo4j-auth/username)" -p "$(cat /config/neo4j-auth/password)"
+    container: neo4j
+    help: |
+      SHOW DATABASES;
+    serviceNameTemplate: '{{- .metadata.name -}}'
   resource:
     group: kubedb.com
     kind: Neo4j

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/oracles.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/oracles.yaml
@@ -85,6 +85,16 @@ spec:
       apiVersion: core.k8s.appscode.com/v1alpha1
       kind: GenericResourceService
     type: MatchName
+  exec:
+  - alias: Primary
+    command:
+    - bash
+    - -c
+    - sqlplus / as sysdba
+    container: oracle
+    help: |
+      SELECT name FROM v$database;
+    serviceNameTemplate: '{{- .metadata.name -}}'
   resource:
     group: kubedb.com
     kind: Oracle

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/pgbouncers.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/pgbouncers.yaml
@@ -85,6 +85,16 @@ spec:
       apiVersion: core.k8s.appscode.com/v1alpha1
       kind: GenericResourceService
     type: MatchName
+  exec:
+  - alias: Primary
+    command:
+    - bash
+    - -c
+    - psql -p 5432 pgbouncer
+    container: pgbouncer
+    help: |
+      SHOW DATABASES;
+    serviceNameTemplate: '{{- .metadata.name -}}'
   resource:
     group: kubedb.com
     kind: PgBouncer

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/pgpools.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/pgpools.yaml
@@ -112,6 +112,16 @@ spec:
       apiVersion: ui.kubedb.com/v1alpha1
       kind: PgpoolSchemaOverview
     type: MatchName
+  exec:
+  - alias: Primary
+    command:
+    - bash
+    - -c
+    - psql -U "$POSTGRES_USERNAME"
+    container: pgpool
+    help: |
+      \l
+    serviceNameTemplate: '{{- .metadata.name -}}'
   resource:
     group: kubedb.com
     kind: Pgpool

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/qdrants.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/qdrants.yaml
@@ -85,6 +85,14 @@ spec:
       apiVersion: core.k8s.appscode.com/v1alpha1
       kind: GenericResourceService
     type: MatchName
+  exec:
+  - alias: Primary
+    command:
+    - bash
+    container: qdrant
+    help: |
+      curl -H "api-key: $QDRANT__SERVICE__API_KEY" "http://localhost:6333/collections"
+    serviceNameTemplate: '{{- .metadata.name -}}'
   resource:
     group: kubedb.com
     kind: Qdrant

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/rabbitmqs.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/rabbitmqs.yaml
@@ -112,6 +112,16 @@ spec:
       apiVersion: ui.kubedb.com/v1alpha1
       kind: RabbitMQSchemaOverview
     type: MatchName
+  exec:
+  - alias: Primary
+    command:
+    - bash
+    - -c
+    - rabbitmqctl status
+    container: rabbitmq
+    help: |
+      rabbitmqctl list_queues
+    serviceNameTemplate: '{{- .metadata.name -}}'
   resource:
     group: kubedb.com
     kind: RabbitMQ

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/redissentinels.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/redissentinels.yaml
@@ -85,6 +85,16 @@ spec:
       apiVersion: core.k8s.appscode.com/v1alpha1
       kind: GenericResourceService
     type: MatchName
+  exec:
+  - alias: Primary
+    command:
+    - bash
+    - -c
+    - redis-cli -p 26379
+    container: redissentinel
+    help: |
+      sentinel masters
+    serviceNameTemplate: '{{- .metadata.name -}}'
   resource:
     group: kubedb.com
     kind: RedisSentinel

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/singlestores.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/singlestores.yaml
@@ -112,6 +112,16 @@ spec:
       apiVersion: ui.kubedb.com/v1alpha1
       kind: SinglestoreSchemaOverview
     type: MatchName
+  exec:
+  - alias: Primary
+    command:
+    - bash
+    - -c
+    - memsql -u "$ROOT_USERNAME" -p"$ROOT_PASSWORD"
+    container: singlestore
+    help: |
+      show databases;
+    serviceNameTemplate: '{{- .metadata.name -}}'
   resource:
     group: kubedb.com
     kind: Singlestore

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/solrs.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/solrs.yaml
@@ -112,6 +112,14 @@ spec:
       apiVersion: ui.kubedb.com/v1alpha1
       kind: SolrSchemaOverview
     type: MatchName
+  exec:
+  - alias: Primary
+    command:
+    - bash
+    container: solr
+    help: |
+      curl -u "$SOLR_USER:$SOLR_PASSWORD" "http://localhost:8983/solr/admin/collections?action=LIST"
+    serviceNameTemplate: '{{- .metadata.name -}}'
   resource:
     group: kubedb.com
     kind: Solr

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/weaviates.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/weaviates.yaml
@@ -85,6 +85,14 @@ spec:
       apiVersion: core.k8s.appscode.com/v1alpha1
       kind: GenericResourceService
     type: MatchName
+  exec:
+  - alias: Primary
+    command:
+    - bash
+    container: weaviate
+    help: |
+      curl "http://localhost:8080/v1/meta"
+    serviceNameTemplate: '{{- .metadata.name -}}'
   resource:
     group: kubedb.com
     kind: Weaviate

--- a/hub/resourcedescriptors/kubedb.com/v1alpha2/zookeepers.yaml
+++ b/hub/resourcedescriptors/kubedb.com/v1alpha2/zookeepers.yaml
@@ -112,6 +112,14 @@ spec:
       apiVersion: ui.kubedb.com/v1alpha1
       kind: ZooKeeperSchemaOverview
     type: MatchName
+  exec:
+  - alias: Primary
+    command:
+    - bash
+    container: zookeeper
+    help: |
+      zkCli.sh -server localhost:2181 ls /
+    serviceNameTemplate: '{{- .metadata.name -}}'
   resource:
     group: kubedb.com
     kind: ZooKeeper


### PR DESCRIPTION
Adds `spec.exec` to 26 kubedb ResourceDescriptors, following the shape already used by `mongodbs`/`postgreses`/`mysqls`, so the UI can open an authenticated shell into the primary container.

Every kubedb RD now has `spec.exec` except `etcds` (see below).

## How the values were derived

- **Container name** — `*ContainerName` constants in `kubedb.dev/apimachinery/apis/kubedb/constants.go`. Verified for all 26.
- **Auth env vars** — same constants file, or each operator's petset builder.
- **`serviceNameTemplate`** — uniformly `{{- .metadata.name -}}`; every DB's `ServiceName()` resolves to `OffshootName()`.

## Notes

- HTTP-only DBs (druid, milvus, qdrant, solr, weaviate) drop into `bash` with a `curl` one-liner in `help`, matching the existing elasticsearch pattern.
- **neo4j** reads credentials from the mounted `/config/neo4j-auth/{username,password}` files rather than env — `NEO4J_USERNAME`/`NEO4J_PASSWORD` are exported only inside the startup script (`neo4j/pkg/controller/config.go:334-335`), so they are not present in a fresh exec shell.
- **aerospike**'s container sets no env vars at all (`aerospike/pkg/controller/petset.go:149-156`), so `asadm` runs bare.
- **mssql** prepends both `/opt/mssql-tools18/bin` and `/opt/mssql-tools/bin` to `PATH`, because the `sqlcmd` location depends on whether the version is >= `2022-cu14` (`mssqlserver/pkg/controller/petset.go:507-511`).
- **etcd is excluded** — there is no etcd operator repo under `kubedb.dev/` and no `EtcdContainerName` constant, so the container name could not be verified.

## Worth a reviewer's eye

Container names and env vars are grep-verified. The **CLI binary names are not** for a subset — these follow upstream convention rather than anything in the operator code: `cqlsh`, `clickhouse-client`, `hdbsql`, `zkCli.sh`, `kafka-topics.sh`, `hz-cli`, `control.sh`, `asadm`, and `psql` for pgbouncer/pgpool. Operator code did confirm `memsql`, `rabbitmqctl`, `sqlplus`, `sqlcmd`, `db2`, and `psql` (documentdb).

## Testing

- `go build ./...` passes
- `cmd/resource-fmt` produces no further changes
- `cmd/check-edge-label` and `cmd/check-embed` pass
- `cmd/check-schema` fails, but fails identically on clean `master` and is not wired into the `fmt` or `ci` targets

## Unrelated observations

- `cmd/gen-resourcedescritors` builds a fresh `ResourceDescriptor` with only `Spec.Resource` set and `os.WriteFile`s over the target without reading it (`main.go:95-129`), so re-running it would wipe `spec.exec` from every DB — including the ones that already had it before this PR.
- `v1/memcacheds.yaml` has a pre-existing `exec` entry with no `container` and no `help`. Left untouched.