### PR TITLE
Make RestoreSession name column a link

### DIFF
--- a/hub/resourcetabledefinitions/core.kubestash.com/v1alpha1/restoresessions.yaml
+++ b/hub/resourcetabledefinitions/core.kubestash.com/v1alpha1/restoresessions.yaml
@@ -9,9 +9,18 @@ metadata:
   name: core.kubestash.com-v1alpha1-restoresessions
 spec:
   columns:
-  - name: Name
+  - link:
+      template: |
+        {{ $apiVersion := .apiVersion }}
+        {{ $name := .metadata.name }}
+        {{ $namespace := .metadata.namespace }}
+        {{- printf "/${username}/${clustername}/%s/restoresessions/%s?namespace=%s" $apiVersion $name $namespace -}}
+    name: Name
     pathTemplate: '{{ .metadata.name }}'
     priority: 3
+    sort:
+      enable: true
+      type: ""
     type: string
   - name: Namespace
     pathTemplate: '{{ .metadata.namespace }}'


### PR DESCRIPTION
The `Name` column in the RestoreSession table definition had no `link.template`, so restore sessions rendered as plain text in the UI while BackupSession, BackupConfiguration and Repository — shown in the same `kubedb-backup` block — rendered as clickable links.

Adds the same `link.template` (and `sort`) those columns use, pointing at the restoresessions detail page.