### PR TITLE
Make OpsRequest name column a link

### DIFF
--- a/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/cassandraopsrequests.yaml
+++ b/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/cassandraopsrequests.yaml
@@ -9,9 +9,18 @@ metadata:
   name: ops.kubedb.com-v1alpha1-cassandraopsrequests-kubedb
 spec:
   columns:
-  - name: Name
+  - link:
+      template: |
+        {{ $apiVersion := .apiVersion }}
+        {{ $name := .metadata.name }}
+        {{ $namespace := .metadata.namespace }}
+        {{- printf "/${username}/${clustername}/%s/cassandraopsrequests/%s?namespace=%s" $apiVersion $name $namespace -}}
+    name: Name
     pathTemplate: '{{ .metadata.name }}'
     priority: 3
+    sort:
+      enable: true
+      type: ""
     type: string
   - name: Namespace
     pathTemplate: '{{ .metadata.namespace }}'

--- a/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/clickhouseopsrequests.yaml
+++ b/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/clickhouseopsrequests.yaml
@@ -9,9 +9,18 @@ metadata:
   name: ops.kubedb.com-v1alpha1-clickhouseopsrequests-kubedb
 spec:
   columns:
-  - name: Name
+  - link:
+      template: |
+        {{ $apiVersion := .apiVersion }}
+        {{ $name := .metadata.name }}
+        {{ $namespace := .metadata.namespace }}
+        {{- printf "/${username}/${clustername}/%s/clickhouseopsrequests/%s?namespace=%s" $apiVersion $name $namespace -}}
+    name: Name
     pathTemplate: '{{ .metadata.name }}'
     priority: 3
+    sort:
+      enable: true
+      type: ""
     type: string
   - name: Namespace
     pathTemplate: '{{ .metadata.namespace }}'

--- a/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/documentdbopsrequests.yaml
+++ b/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/documentdbopsrequests.yaml
@@ -9,9 +9,18 @@ metadata:
   name: ops.kubedb.com-v1alpha1-documentdbopsrequests-kubedb
 spec:
   columns:
-  - name: Name
+  - link:
+      template: |
+        {{ $apiVersion := .apiVersion }}
+        {{ $name := .metadata.name }}
+        {{ $namespace := .metadata.namespace }}
+        {{- printf "/${username}/${clustername}/%s/documentdbopsrequests/%s?namespace=%s" $apiVersion $name $namespace -}}
+    name: Name
     pathTemplate: '{{ .metadata.name }}'
     priority: 3
+    sort:
+      enable: true
+      type: ""
     type: string
   - name: Namespace
     pathTemplate: '{{ .metadata.namespace }}'

--- a/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/druidopsrequests.yaml
+++ b/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/druidopsrequests.yaml
@@ -9,9 +9,18 @@ metadata:
   name: ops.kubedb.com-v1alpha1-druidopsrequests-kubedb
 spec:
   columns:
-  - name: Name
+  - link:
+      template: |
+        {{ $apiVersion := .apiVersion }}
+        {{ $name := .metadata.name }}
+        {{ $namespace := .metadata.namespace }}
+        {{- printf "/${username}/${clustername}/%s/druidopsrequests/%s?namespace=%s" $apiVersion $name $namespace -}}
+    name: Name
     pathTemplate: '{{ .metadata.name }}'
     priority: 3
+    sort:
+      enable: true
+      type: ""
     type: string
   - name: Namespace
     pathTemplate: '{{ .metadata.namespace }}'

--- a/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/elasticsearchopsrequests.yaml
+++ b/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/elasticsearchopsrequests.yaml
@@ -9,9 +9,18 @@ metadata:
   name: ops.kubedb.com-v1alpha1-elasticsearchopsrequests-kubedb
 spec:
   columns:
-  - name: Name
+  - link:
+      template: |
+        {{ $apiVersion := .apiVersion }}
+        {{ $name := .metadata.name }}
+        {{ $namespace := .metadata.namespace }}
+        {{- printf "/${username}/${clustername}/%s/elasticsearchopsrequests/%s?namespace=%s" $apiVersion $name $namespace -}}
+    name: Name
     pathTemplate: '{{ .metadata.name }}'
     priority: 3
+    sort:
+      enable: true
+      type: ""
     type: string
   - name: Namespace
     pathTemplate: '{{ .metadata.namespace }}'

--- a/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/hanadbopsrequests.yaml
+++ b/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/hanadbopsrequests.yaml
@@ -9,9 +9,18 @@ metadata:
   name: ops.kubedb.com-v1alpha1-hanadbopsrequests-kubedb
 spec:
   columns:
-  - name: Name
+  - link:
+      template: |
+        {{ $apiVersion := .apiVersion }}
+        {{ $name := .metadata.name }}
+        {{ $namespace := .metadata.namespace }}
+        {{- printf "/${username}/${clustername}/%s/hanadbopsrequests/%s?namespace=%s" $apiVersion $name $namespace -}}
+    name: Name
     pathTemplate: '{{ .metadata.name }}'
     priority: 3
+    sort:
+      enable: true
+      type: ""
     type: string
   - name: Namespace
     pathTemplate: '{{ .metadata.namespace }}'

--- a/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/hazelcastopsrequests.yaml
+++ b/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/hazelcastopsrequests.yaml
@@ -9,9 +9,18 @@ metadata:
   name: ops.kubedb.com-v1alpha1-hazelcastopsrequests-kubedb
 spec:
   columns:
-  - name: Name
+  - link:
+      template: |
+        {{ $apiVersion := .apiVersion }}
+        {{ $name := .metadata.name }}
+        {{ $namespace := .metadata.namespace }}
+        {{- printf "/${username}/${clustername}/%s/hazelcastopsrequests/%s?namespace=%s" $apiVersion $name $namespace -}}
+    name: Name
     pathTemplate: '{{ .metadata.name }}'
     priority: 3
+    sort:
+      enable: true
+      type: ""
     type: string
   - name: Namespace
     pathTemplate: '{{ .metadata.namespace }}'

--- a/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/igniteopsrequests.yaml
+++ b/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/igniteopsrequests.yaml
@@ -9,9 +9,18 @@ metadata:
   name: ops.kubedb.com-v1alpha1-igniteopsrequests-kubedb
 spec:
   columns:
-  - name: Name
+  - link:
+      template: |
+        {{ $apiVersion := .apiVersion }}
+        {{ $name := .metadata.name }}
+        {{ $namespace := .metadata.namespace }}
+        {{- printf "/${username}/${clustername}/%s/igniteopsrequests/%s?namespace=%s" $apiVersion $name $namespace -}}
+    name: Name
     pathTemplate: '{{ .metadata.name }}'
     priority: 3
+    sort:
+      enable: true
+      type: ""
     type: string
   - name: Namespace
     pathTemplate: '{{ .metadata.namespace }}'

--- a/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/kafkaopsrequests.yaml
+++ b/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/kafkaopsrequests.yaml
@@ -9,9 +9,18 @@ metadata:
   name: ops.kubedb.com-v1alpha1-kafkaopsrequests-kubedb
 spec:
   columns:
-  - name: Name
+  - link:
+      template: |
+        {{ $apiVersion := .apiVersion }}
+        {{ $name := .metadata.name }}
+        {{ $namespace := .metadata.namespace }}
+        {{- printf "/${username}/${clustername}/%s/kafkaopsrequests/%s?namespace=%s" $apiVersion $name $namespace -}}
+    name: Name
     pathTemplate: '{{ .metadata.name }}'
     priority: 3
+    sort:
+      enable: true
+      type: ""
     type: string
   - name: Namespace
     pathTemplate: '{{ .metadata.namespace }}'

--- a/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/mariadbopsrequests.yaml
+++ b/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/mariadbopsrequests.yaml
@@ -9,9 +9,18 @@ metadata:
   name: ops.kubedb.com-v1alpha1-mariadbopsrequests-kubedb
 spec:
   columns:
-  - name: Name
+  - link:
+      template: |
+        {{ $apiVersion := .apiVersion }}
+        {{ $name := .metadata.name }}
+        {{ $namespace := .metadata.namespace }}
+        {{- printf "/${username}/${clustername}/%s/mariadbopsrequests/%s?namespace=%s" $apiVersion $name $namespace -}}
+    name: Name
     pathTemplate: '{{ .metadata.name }}'
     priority: 3
+    sort:
+      enable: true
+      type: ""
     type: string
   - name: Namespace
     pathTemplate: '{{ .metadata.namespace }}'

--- a/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/memcachedopsrequests.yaml
+++ b/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/memcachedopsrequests.yaml
@@ -9,9 +9,18 @@ metadata:
   name: ops.kubedb.com-v1alpha1-memcachedopsrequests-kubedb
 spec:
   columns:
-  - name: Name
+  - link:
+      template: |
+        {{ $apiVersion := .apiVersion }}
+        {{ $name := .metadata.name }}
+        {{ $namespace := .metadata.namespace }}
+        {{- printf "/${username}/${clustername}/%s/memcachedopsrequests/%s?namespace=%s" $apiVersion $name $namespace -}}
+    name: Name
     pathTemplate: '{{ .metadata.name }}'
     priority: 3
+    sort:
+      enable: true
+      type: ""
     type: string
   - name: Namespace
     pathTemplate: '{{ .metadata.namespace }}'

--- a/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/milvusopsrequests.yaml
+++ b/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/milvusopsrequests.yaml
@@ -9,9 +9,18 @@ metadata:
   name: ops.kubedb.com-v1alpha1-milvusopsrequests-kubedb
 spec:
   columns:
-  - name: Name
+  - link:
+      template: |
+        {{ $apiVersion := .apiVersion }}
+        {{ $name := .metadata.name }}
+        {{ $namespace := .metadata.namespace }}
+        {{- printf "/${username}/${clustername}/%s/milvusopsrequests/%s?namespace=%s" $apiVersion $name $namespace -}}
+    name: Name
     pathTemplate: '{{ .metadata.name }}'
     priority: 3
+    sort:
+      enable: true
+      type: ""
     type: string
   - name: Namespace
     pathTemplate: '{{ .metadata.namespace }}'

--- a/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/mongodbopsrequests.yaml
+++ b/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/mongodbopsrequests.yaml
@@ -9,9 +9,18 @@ metadata:
   name: ops.kubedb.com-v1alpha1-mongodbopsrequests-kubedb
 spec:
   columns:
-  - name: Name
+  - link:
+      template: |
+        {{ $apiVersion := .apiVersion }}
+        {{ $name := .metadata.name }}
+        {{ $namespace := .metadata.namespace }}
+        {{- printf "/${username}/${clustername}/%s/mongodbopsrequests/%s?namespace=%s" $apiVersion $name $namespace -}}
+    name: Name
     pathTemplate: '{{ .metadata.name }}'
     priority: 3
+    sort:
+      enable: true
+      type: ""
     type: string
   - name: Namespace
     pathTemplate: '{{ .metadata.namespace }}'

--- a/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/mssqlserveropsrequests.yaml
+++ b/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/mssqlserveropsrequests.yaml
@@ -9,9 +9,18 @@ metadata:
   name: ops.kubedb.com-v1alpha1-mssqlserveropsrequests-kubedb
 spec:
   columns:
-  - name: Name
+  - link:
+      template: |
+        {{ $apiVersion := .apiVersion }}
+        {{ $name := .metadata.name }}
+        {{ $namespace := .metadata.namespace }}
+        {{- printf "/${username}/${clustername}/%s/mssqlserveropsrequests/%s?namespace=%s" $apiVersion $name $namespace -}}
+    name: Name
     pathTemplate: '{{ .metadata.name }}'
     priority: 3
+    sort:
+      enable: true
+      type: ""
     type: string
   - name: Namespace
     pathTemplate: '{{ .metadata.namespace }}'

--- a/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/mysqlopsrequests.yaml
+++ b/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/mysqlopsrequests.yaml
@@ -9,9 +9,18 @@ metadata:
   name: ops.kubedb.com-v1alpha1-mysqlopsrequests-kubedb
 spec:
   columns:
-  - name: Name
+  - link:
+      template: |
+        {{ $apiVersion := .apiVersion }}
+        {{ $name := .metadata.name }}
+        {{ $namespace := .metadata.namespace }}
+        {{- printf "/${username}/${clustername}/%s/mysqlopsrequests/%s?namespace=%s" $apiVersion $name $namespace -}}
+    name: Name
     pathTemplate: '{{ .metadata.name }}'
     priority: 3
+    sort:
+      enable: true
+      type: ""
     type: string
   - name: Namespace
     pathTemplate: '{{ .metadata.namespace }}'

--- a/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/neo4jopsrequests.yaml
+++ b/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/neo4jopsrequests.yaml
@@ -9,9 +9,18 @@ metadata:
   name: ops.kubedb.com-v1alpha1-neo4jopsrequests-kubedb
 spec:
   columns:
-  - name: Name
+  - link:
+      template: |
+        {{ $apiVersion := .apiVersion }}
+        {{ $name := .metadata.name }}
+        {{ $namespace := .metadata.namespace }}
+        {{- printf "/${username}/${clustername}/%s/neo4jopsrequests/%s?namespace=%s" $apiVersion $name $namespace -}}
+    name: Name
     pathTemplate: '{{ .metadata.name }}'
     priority: 3
+    sort:
+      enable: true
+      type: ""
     type: string
   - name: Namespace
     pathTemplate: '{{ .metadata.namespace }}'

--- a/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/oracleopsrequests.yaml
+++ b/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/oracleopsrequests.yaml
@@ -9,9 +9,18 @@ metadata:
   name: ops.kubedb.com-v1alpha1-oracleopsrequests-kubedb
 spec:
   columns:
-  - name: Name
+  - link:
+      template: |
+        {{ $apiVersion := .apiVersion }}
+        {{ $name := .metadata.name }}
+        {{ $namespace := .metadata.namespace }}
+        {{- printf "/${username}/${clustername}/%s/oracleopsrequests/%s?namespace=%s" $apiVersion $name $namespace -}}
+    name: Name
     pathTemplate: '{{ .metadata.name }}'
     priority: 3
+    sort:
+      enable: true
+      type: ""
     type: string
   - name: Namespace
     pathTemplate: '{{ .metadata.namespace }}'

--- a/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/perconaztradbopsrequests.yaml
+++ b/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/perconaztradbopsrequests.yaml
@@ -9,9 +9,18 @@ metadata:
   name: ops.kubedb.com-v1alpha1-perconaxtradbopsrequests-kubedb
 spec:
   columns:
-  - name: Name
+  - link:
+      template: |
+        {{ $apiVersion := .apiVersion }}
+        {{ $name := .metadata.name }}
+        {{ $namespace := .metadata.namespace }}
+        {{- printf "/${username}/${clustername}/%s/perconaxtradbopsrequests/%s?namespace=%s" $apiVersion $name $namespace -}}
+    name: Name
     pathTemplate: '{{ .metadata.name }}'
     priority: 3
+    sort:
+      enable: true
+      type: ""
     type: string
   - name: Namespace
     pathTemplate: '{{ .metadata.namespace }}'

--- a/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/pgbounceropsrequests.yaml
+++ b/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/pgbounceropsrequests.yaml
@@ -9,9 +9,18 @@ metadata:
   name: ops.kubedb.com-v1alpha1-pgbounceropsrequests-kubedb
 spec:
   columns:
-  - name: Name
+  - link:
+      template: |
+        {{ $apiVersion := .apiVersion }}
+        {{ $name := .metadata.name }}
+        {{ $namespace := .metadata.namespace }}
+        {{- printf "/${username}/${clustername}/%s/pgbounceropsrequests/%s?namespace=%s" $apiVersion $name $namespace -}}
+    name: Name
     pathTemplate: '{{ .metadata.name }}'
     priority: 3
+    sort:
+      enable: true
+      type: ""
     type: string
   - name: Namespace
     pathTemplate: '{{ .metadata.namespace }}'

--- a/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/pgpoolopsrequests.yaml
+++ b/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/pgpoolopsrequests.yaml
@@ -9,9 +9,18 @@ metadata:
   name: ops.kubedb.com-v1alpha1-pgpoolopsrequests-kubedb
 spec:
   columns:
-  - name: Name
+  - link:
+      template: |
+        {{ $apiVersion := .apiVersion }}
+        {{ $name := .metadata.name }}
+        {{ $namespace := .metadata.namespace }}
+        {{- printf "/${username}/${clustername}/%s/pgpoolopsrequests/%s?namespace=%s" $apiVersion $name $namespace -}}
+    name: Name
     pathTemplate: '{{ .metadata.name }}'
     priority: 3
+    sort:
+      enable: true
+      type: ""
     type: string
   - name: Namespace
     pathTemplate: '{{ .metadata.namespace }}'

--- a/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/postgresopsrequests.yaml
+++ b/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/postgresopsrequests.yaml
@@ -9,9 +9,18 @@ metadata:
   name: ops.kubedb.com-v1alpha1-postgresopsrequests-kubedb
 spec:
   columns:
-  - name: Name
+  - link:
+      template: |
+        {{ $apiVersion := .apiVersion }}
+        {{ $name := .metadata.name }}
+        {{ $namespace := .metadata.namespace }}
+        {{- printf "/${username}/${clustername}/%s/postgresopsrequests/%s?namespace=%s" $apiVersion $name $namespace -}}
+    name: Name
     pathTemplate: '{{ .metadata.name }}'
     priority: 3
+    sort:
+      enable: true
+      type: ""
     type: string
   - name: Namespace
     pathTemplate: '{{ .metadata.namespace }}'

--- a/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/proxysqlopsrequests.yaml
+++ b/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/proxysqlopsrequests.yaml
@@ -9,9 +9,18 @@ metadata:
   name: ops.kubedb.com-v1alpha1-proxysqlopsrequests-kubedb
 spec:
   columns:
-  - name: Name
+  - link:
+      template: |
+        {{ $apiVersion := .apiVersion }}
+        {{ $name := .metadata.name }}
+        {{ $namespace := .metadata.namespace }}
+        {{- printf "/${username}/${clustername}/%s/proxysqlopsrequests/%s?namespace=%s" $apiVersion $name $namespace -}}
+    name: Name
     pathTemplate: '{{ .metadata.name }}'
     priority: 3
+    sort:
+      enable: true
+      type: ""
     type: string
   - name: Namespace
     pathTemplate: '{{ .metadata.namespace }}'

--- a/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/qdrantopsrequests.yaml
+++ b/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/qdrantopsrequests.yaml
@@ -9,9 +9,18 @@ metadata:
   name: ops.kubedb.com-v1alpha1-qdrantopsrequests-kubedb
 spec:
   columns:
-  - name: Name
+  - link:
+      template: |
+        {{ $apiVersion := .apiVersion }}
+        {{ $name := .metadata.name }}
+        {{ $namespace := .metadata.namespace }}
+        {{- printf "/${username}/${clustername}/%s/qdrantopsrequests/%s?namespace=%s" $apiVersion $name $namespace -}}
+    name: Name
     pathTemplate: '{{ .metadata.name }}'
     priority: 3
+    sort:
+      enable: true
+      type: ""
     type: string
   - name: Namespace
     pathTemplate: '{{ .metadata.namespace }}'

--- a/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/rabbitmqopsrequests.yaml
+++ b/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/rabbitmqopsrequests.yaml
@@ -9,9 +9,18 @@ metadata:
   name: ops.kubedb.com-v1alpha1-rabbitmqopsrequests-kubedb
 spec:
   columns:
-  - name: Name
+  - link:
+      template: |
+        {{ $apiVersion := .apiVersion }}
+        {{ $name := .metadata.name }}
+        {{ $namespace := .metadata.namespace }}
+        {{- printf "/${username}/${clustername}/%s/rabbitmqopsrequests/%s?namespace=%s" $apiVersion $name $namespace -}}
+    name: Name
     pathTemplate: '{{ .metadata.name }}'
     priority: 3
+    sort:
+      enable: true
+      type: ""
     type: string
   - name: Namespace
     pathTemplate: '{{ .metadata.namespace }}'

--- a/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/redisopsrequests.yaml
+++ b/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/redisopsrequests.yaml
@@ -9,9 +9,18 @@ metadata:
   name: ops.kubedb.com-v1alpha1-redisopsrequests-kubedb
 spec:
   columns:
-  - name: Name
+  - link:
+      template: |
+        {{ $apiVersion := .apiVersion }}
+        {{ $name := .metadata.name }}
+        {{ $namespace := .metadata.namespace }}
+        {{- printf "/${username}/${clustername}/%s/redisopsrequests/%s?namespace=%s" $apiVersion $name $namespace -}}
+    name: Name
     pathTemplate: '{{ .metadata.name }}'
     priority: 3
+    sort:
+      enable: true
+      type: ""
     type: string
   - name: Namespace
     pathTemplate: '{{ .metadata.namespace }}'

--- a/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/singlestoreopsrequests.yaml
+++ b/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/singlestoreopsrequests.yaml
@@ -9,9 +9,18 @@ metadata:
   name: ops.kubedb.com-v1alpha1-singlestoreopsrequests-kubedb
 spec:
   columns:
-  - name: Name
+  - link:
+      template: |
+        {{ $apiVersion := .apiVersion }}
+        {{ $name := .metadata.name }}
+        {{ $namespace := .metadata.namespace }}
+        {{- printf "/${username}/${clustername}/%s/singlestoreopsrequests/%s?namespace=%s" $apiVersion $name $namespace -}}
+    name: Name
     pathTemplate: '{{ .metadata.name }}'
     priority: 3
+    sort:
+      enable: true
+      type: ""
     type: string
   - name: Namespace
     pathTemplate: '{{ .metadata.namespace }}'

--- a/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/solropsrequests.yaml
+++ b/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/solropsrequests.yaml
@@ -9,9 +9,18 @@ metadata:
   name: ops.kubedb.com-v1alpha1-solropsrequests-kubedb
 spec:
   columns:
-  - name: Name
+  - link:
+      template: |
+        {{ $apiVersion := .apiVersion }}
+        {{ $name := .metadata.name }}
+        {{ $namespace := .metadata.namespace }}
+        {{- printf "/${username}/${clustername}/%s/solropsrequests/%s?namespace=%s" $apiVersion $name $namespace -}}
+    name: Name
     pathTemplate: '{{ .metadata.name }}'
     priority: 3
+    sort:
+      enable: true
+      type: ""
     type: string
   - name: Namespace
     pathTemplate: '{{ .metadata.namespace }}'

--- a/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/weaviateopsrequests.yaml
+++ b/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/weaviateopsrequests.yaml
@@ -9,9 +9,18 @@ metadata:
   name: ops.kubedb.com-v1alpha1-weaviateopsrequests-kubedb
 spec:
   columns:
-  - name: Name
+  - link:
+      template: |
+        {{ $apiVersion := .apiVersion }}
+        {{ $name := .metadata.name }}
+        {{ $namespace := .metadata.namespace }}
+        {{- printf "/${username}/${clustername}/%s/weaviateopsrequests/%s?namespace=%s" $apiVersion $name $namespace -}}
+    name: Name
     pathTemplate: '{{ .metadata.name }}'
     priority: 3
+    sort:
+      enable: true
+      type: ""
     type: string
   - name: Namespace
     pathTemplate: '{{ .metadata.namespace }}'

--- a/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/zookeeperopsrequests.yaml
+++ b/hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/zookeeperopsrequests.yaml
@@ -9,9 +9,18 @@ metadata:
   name: ops.kubedb.com-v1alpha1-zookeeperopsrequests-kubedb
 spec:
   columns:
-  - name: Name
+  - link:
+      template: |
+        {{ $apiVersion := .apiVersion }}
+        {{ $name := .metadata.name }}
+        {{ $namespace := .metadata.namespace }}
+        {{- printf "/${username}/${clustername}/%s/zookeeperopsrequests/%s?namespace=%s" $apiVersion $name $namespace -}}
+    name: Name
     pathTemplate: '{{ .metadata.name }}'
     priority: 3
+    sort:
+      enable: true
+      type: ""
     type: string
   - name: Namespace
     pathTemplate: '{{ .metadata.namespace }}'

--- a/hub/resourcetabledefinitions/supervisor.appscode.com/v1alpha1/kubedb/recommendations.yaml
+++ b/hub/resourcetabledefinitions/supervisor.appscode.com/v1alpha1/kubedb/recommendations.yaml
@@ -9,9 +9,18 @@ metadata:
   name: supervisor.appscode.com-v1alpha1-recommendations-kubedb
 spec:
   columns:
-  - name: Name
+  - link:
+      template: |
+        {{ $apiVersion := .apiVersion }}
+        {{ $name := .metadata.name }}
+        {{ $namespace := .metadata.namespace }}
+        {{- printf "/${username}/${clustername}/%s/recommendations/%s?namespace=%s" $apiVersion $name $namespace -}}
+    name: Name
     pathTemplate: '{{ .metadata.name }}'
     priority: 3
+    sort:
+      enable: true
+      type: ""
     type: string
   - name: Namespace
     pathTemplate: '{{ .metadata.namespace }}'


### PR DESCRIPTION
Adds a link template (and enables sorting) on the Name column of the `kubedb` sub-view OpsRequest table definitions, matching the pattern used for RestoreSession in #664.

Only `hub/resourcetabledefinitions/ops.kubedb.com/v1alpha1/kubedb/` files are touched (29 files).