### PR TITLE
Sort recent backup & restore session lists newest first

### DIFF
--- a/hub/resourceblockdefinitions/core.kubestash.com/v1alpha1/kubedb-backup.yaml
+++ b/hub/resourceblockdefinitions/core.kubestash.com/v1alpha1/kubedb-backup.yaml
@@ -55,6 +55,10 @@ spec:
     ref:
       group: core.kubestash.com
       kind: BackupConfiguration
+    view:
+      sort:
+        fieldName: Age
+        order: Ascending
   - actions:
       create: IfEmpty
     displayMode: List
@@ -66,6 +70,10 @@ spec:
     ref:
       group: storage.kubestash.com
       kind: Repository
+    view:
+      sort:
+        fieldName: Age
+        order: Ascending
   - actions:
       create: Never
     displayMode: List
@@ -87,3 +95,7 @@ spec:
     ref:
       group: batch
       kind: CronJob
+    view:
+      sort:
+        fieldName: Age
+        order: Ascending

--- a/hub/resourceblockdefinitions/core.kubestash.com/v1alpha1/kubedb-backup.yaml
+++ b/hub/resourceblockdefinitions/core.kubestash.com/v1alpha1/kubedb-backup.yaml
@@ -25,6 +25,10 @@ spec:
     ref:
       group: core.kubestash.com
       kind: BackupSession
+    view:
+      sort:
+        fieldName: Age
+        order: Ascending
   - actions:
       create: Always
     displayMode: List
@@ -36,6 +40,10 @@ spec:
     ref:
       group: core.kubestash.com
       kind: RestoreSession
+    view:
+      sort:
+        fieldName: Age
+        order: Ascending
   - actions:
       create: IfEmpty
     displayMode: List


### PR DESCRIPTION
Adds a default `Age`-ascending sort (newest first) to the **Recent Backups** (BackupSession) and **Recent Restores** (RestoreSession) blocks in the kubedb-backup ResourceBlockDefinition.

Matches the existing hub convention (`fieldName: Age`, `order: Ascending`) used in the kubedb resource outlines. A `view` with only `sort` keeps the default table columns — `Convert_PageBlockOutline_To_PageBlockLayout` still resolves the default table definition for the GVK and passes `sort` through (pkg/layouts/lib.go:431-465).