### PR TITLE
Sync KubeDB ResourceDashboards with the dashboard charts

### DIFF
--- a/hub/resourcedashboards/kafka.kubedb.com/v1alpha1/connectclusters.yaml
+++ b/hub/resourcedashboards/kafka.kubedb.com/v1alpha1/connectclusters.yaml
@@ -2,26 +2,26 @@ apiVersion: ui.k8s.appscode.com/v1alpha1
 kind: ResourceDashboard
 metadata:
   labels:
-    k8s.io/group: kubedb.com
-    k8s.io/kind: Weaviate
-    k8s.io/resource: weaviates
-    k8s.io/version: v1alpha2
-  name: kubedb.com-v1alpha2-weaviates
+    k8s.io/group: kafka.kubedb.com
+    k8s.io/kind: ConnectCluster
+    k8s.io/resource: connectclusters
+    k8s.io/version: v1alpha1
+  name: kafka.kubedb.com-v1alpha1-connectclusters
 spec:
   dashboards:
-  - title: KubeDB / Weaviate / Summary
+  - title: KubeDB / Kafka / ConnectCluster / Summary
     vars:
     - name: namespace
       value: '{{ .metadata.namespace }}'
     - name: app
       value: '{{ .metadata.name }}'
-  - title: KubeDB / Weaviate / Database
+  - title: KubeDB / Kafka / ConnectCluster / Connect
     vars:
     - name: namespace
       value: '{{ .metadata.namespace }}'
     - name: app
       value: '{{ .metadata.name }}'
-  - title: KubeDB / Weaviate / Pod
+  - title: KubeDB / Kafka / ConnectCluster / Pod
     vars:
     - name: namespace
       value: '{{ .metadata.namespace }}'
@@ -29,8 +29,8 @@ spec:
       value: '{{ .metadata.name }}'
   provider: Grafana
   resource:
-    group: kubedb.com
-    kind: Weaviate
-    name: weaviates
+    group: kafka.kubedb.com
+    kind: ConnectCluster
+    name: connectclusters
     scope: Namespaced
-    version: v1alpha2
+    version: v1alpha1

--- a/hub/resourcedashboards/kubedb.com/v1/kafkas.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1/kafkas.yaml
@@ -9,11 +9,23 @@ metadata:
   name: kubedb.com-v1-kafkas
 spec:
   dashboards:
+  - title: KubeDB / Kafka / Summary
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
   - title: KubeDB / Kafka / Database
     vars:
     - name: namespace
       value: '{{ .metadata.namespace }}'
-    - name: service
+    - name: app
+      value: '{{ .metadata.name }}'
+  - title: KubeDB / Kafka / Pod
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
       value: '{{ .metadata.name }}'
   provider: Grafana
   resource:

--- a/hub/resourcedashboards/kubedb.com/v1/mariadbs.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1/mariadbs.yaml
@@ -23,6 +23,14 @@ spec:
       value: '{{ .metadata.namespace }}'
     - name: app
       value: '{{ .metadata.name }}'
+  - if:
+      condition: '{{- if eq (dig "topology" "mode" "" .spec) "MariaDBReplication" }}true{{ else }}false{{ end -}}'
+    title: KubeDB / MariaDB / Standard Replication
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
   - title: KubeDB / MariaDB / Database
     vars:
     - name: namespace

--- a/hub/resourcedashboards/kubedb.com/v1/mariadbs.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1/mariadbs.yaml
@@ -16,7 +16,7 @@ spec:
     - name: app
       value: '{{ .metadata.name }}'
   - if:
-      condition: '{{- if eq .spec.replicas 1 }}false{{ else }}true{{ end -}}'
+      condition: '{{- if and (ne .spec.replicas 1) (ne (dig "topology" "mode" "GaleraCluster" .spec) "MariaDBReplication") }}true{{ else }}false{{ end -}}'
     title: KubeDB / MariaDB / Galera-Cluster
     vars:
     - name: namespace

--- a/hub/resourcedashboards/kubedb.com/v1/memcacheds.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1/memcacheds.yaml
@@ -16,17 +16,7 @@ spec:
     - name: app
       value: '{{ .metadata.name }}'
   - title: KubeDB / Memcached / Database
-    vars:
-    - name: namespace
-      value: '{{ .metadata.namespace }}'
-    - name: app
-      value: '{{ .metadata.name }}'
   - title: KubeDB / Memcached / Pod
-    vars:
-    - name: namespace
-      value: '{{ .metadata.namespace }}'
-    - name: app
-      value: '{{ .metadata.name }}'
   provider: Grafana
   resource:
     group: kubedb.com

--- a/hub/resourcedashboards/kubedb.com/v1/memcacheds.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1/memcacheds.yaml
@@ -8,7 +8,25 @@ metadata:
     k8s.io/version: v1
   name: kubedb.com-v1-memcacheds
 spec:
-  dashboards: null
+  dashboards:
+  - title: KubeDB / Memcached / Summary
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
+  - title: KubeDB / Memcached / Database
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
+  - title: KubeDB / Memcached / Pod
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
   provider: Grafana
   resource:
     group: kubedb.com

--- a/hub/resourcedashboards/kubedb.com/v1/perconaxtradbs.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1/perconaxtradbs.yaml
@@ -8,7 +8,33 @@ metadata:
     k8s.io/version: v1
   name: kubedb.com-v1-perconaxtradbs
 spec:
-  dashboards: null
+  dashboards:
+  - title: KubeDB / PerconaXtraDB / Summary
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
+  - if:
+      condition: '{{- if eq .spec.replicas 1 }}false{{ else }}true{{ end -}}'
+    title: KubeDB / PerconaXtraDB / Galera-Cluster
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
+  - title: KubeDB / PerconaXtraDB / Database
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
+  - title: KubeDB / PerconaXtraDB / Pod
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
   provider: Grafana
   resource:
     group: kubedb.com

--- a/hub/resourcedashboards/kubedb.com/v1/pgbouncers.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1/pgbouncers.yaml
@@ -8,7 +8,25 @@ metadata:
     k8s.io/version: v1
   name: kubedb.com-v1-pgbouncers
 spec:
-  dashboards: null
+  dashboards:
+  - title: KubeDB / PgBouncer / Summary
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
+  - title: KubeDB / PgBouncer / Database
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
+  - title: KubeDB / PgBouncer / Pod
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
   provider: Grafana
   resource:
     group: kubedb.com

--- a/hub/resourcedashboards/kubedb.com/v1/pod/perconaxtradbs.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1/pod/perconaxtradbs.yaml
@@ -1,0 +1,18 @@
+apiVersion: ui.k8s.appscode.com/v1alpha1
+kind: ResourceDashboard
+metadata:
+  name: kubedb.com-v1-perconaxtradbs-pod
+spec:
+  dashboards:
+  - title: KubeDB / PerconaXtraDB / Pod
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
+    - name: pod
+      type: Target
+      value: '{{ .metadata.name }}'
+  provider: Grafana
+  resource:
+    group: ""

--- a/hub/resourcedashboards/kubedb.com/v1/pod/pgbouncers.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1/pod/pgbouncers.yaml
@@ -1,0 +1,18 @@
+apiVersion: ui.k8s.appscode.com/v1alpha1
+kind: ResourceDashboard
+metadata:
+  name: kubedb.com-v1-pgbouncers-pod
+spec:
+  dashboards:
+  - title: KubeDB / PgBouncer / Pod
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
+    - name: pod
+      type: Target
+      value: '{{ .metadata.name }}'
+  provider: Grafana
+  resource:
+    group: ""

--- a/hub/resourcedashboards/kubedb.com/v1/postgreses.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1/postgreses.yaml
@@ -15,6 +15,14 @@ spec:
       value: '{{ .metadata.namespace }}'
     - name: app
       value: '{{ .metadata.name }}'
+  - if:
+      condition: '{{- if hasKey .spec "remoteReplica" }}true{{ else }}false{{ end -}}'
+    title: KubeDB / Postgres / Remote Replica
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
   - title: KubeDB / Postgres / Database
     vars:
     - name: namespace

--- a/hub/resourcedashboards/kubedb.com/v1/redissentinels.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1/redissentinels.yaml
@@ -8,7 +8,19 @@ metadata:
     k8s.io/version: v1
   name: kubedb.com-v1-redissentinels
 spec:
-  dashboards: null
+  dashboards:
+  - title: KubeDB / RedisSentinel / Summary
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
+  - title: KubeDB / RedisSentinel / Pod
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
   provider: Grafana
   resource:
     group: kubedb.com

--- a/hub/resourcedashboards/kubedb.com/v1alpha2/cassandra.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1alpha2/cassandra.yaml
@@ -16,17 +16,7 @@ spec:
     - name: app
       value: '{{ .metadata.name }}'
   - title: KubeDB / Cassandra / Database
-    vars:
-    - name: namespace
-      value: '{{ .metadata.namespace }}'
-    - name: app
-      value: '{{ .metadata.name }}'
   - title: KubeDB / Cassandra / Pod
-    vars:
-    - name: namespace
-      value: '{{ .metadata.namespace }}'
-    - name: app
-      value: '{{ .metadata.name }}'
   provider: Grafana
   resource:
     group: kubedb.com

--- a/hub/resourcedashboards/kubedb.com/v1alpha2/hanadbs.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1alpha2/hanadbs.yaml
@@ -21,12 +21,6 @@ spec:
       value: '{{ .metadata.namespace }}'
     - name: app
       value: '{{ .metadata.name }}'
-  - title: KubeDB / HanaDB / Pod
-    vars:
-    - name: namespace
-      value: '{{ .metadata.namespace }}'
-    - name: app
-      value: '{{ .metadata.name }}'
   provider: Grafana
   resource:
     group: kubedb.com

--- a/hub/resourcedashboards/kubedb.com/v1alpha2/hanadbs.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1alpha2/hanadbs.yaml
@@ -16,11 +16,6 @@ spec:
     - name: app
       value: '{{ .metadata.name }}'
   - title: KubeDB / HanaDB / Database
-    vars:
-    - name: namespace
-      value: '{{ .metadata.namespace }}'
-    - name: app
-      value: '{{ .metadata.name }}'
   provider: Grafana
   resource:
     group: kubedb.com

--- a/hub/resourcedashboards/kubedb.com/v1alpha2/ignites.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1alpha2/ignites.yaml
@@ -17,16 +17,9 @@ spec:
       value: '{{ .metadata.name }}'
   - title: KubeDB / Ignite / Database
     vars:
-    - name: namespace
-      value: '{{ .metadata.namespace }}'
     - name: app
       value: '{{ .metadata.name }}'
   - title: KubeDB / Ignite / Pod
-    vars:
-    - name: namespace
-      value: '{{ .metadata.namespace }}'
-    - name: app
-      value: '{{ .metadata.name }}'
   provider: Grafana
   resource:
     group: kubedb.com

--- a/hub/resourcedashboards/kubedb.com/v1alpha2/kafkas.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1alpha2/kafkas.yaml
@@ -9,11 +9,23 @@ metadata:
   name: kubedb.com-v1alpha2-kafkas
 spec:
   dashboards:
+  - title: KubeDB / Kafka / Summary
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
   - title: KubeDB / Kafka / Database
     vars:
     - name: namespace
       value: '{{ .metadata.namespace }}'
-    - name: service
+    - name: app
+      value: '{{ .metadata.name }}'
+  - title: KubeDB / Kafka / Pod
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
       value: '{{ .metadata.name }}'
   provider: Grafana
   resource:

--- a/hub/resourcedashboards/kubedb.com/v1alpha2/mariadbs.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1alpha2/mariadbs.yaml
@@ -23,6 +23,14 @@ spec:
       value: '{{ .metadata.namespace }}'
     - name: app
       value: '{{ .metadata.name }}'
+  - if:
+      condition: '{{- if eq (dig "topology" "mode" "" .spec) "MariaDBReplication" }}true{{ else }}false{{ end -}}'
+    title: KubeDB / MariaDB / Standard Replication
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
   - title: KubeDB / MariaDB / Database
     vars:
     - name: namespace

--- a/hub/resourcedashboards/kubedb.com/v1alpha2/mariadbs.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1alpha2/mariadbs.yaml
@@ -16,7 +16,7 @@ spec:
     - name: app
       value: '{{ .metadata.name }}'
   - if:
-      condition: '{{- if eq .spec.replicas 1 }}false{{ else }}true{{ end -}}'
+      condition: '{{- if and (ne .spec.replicas 1) (ne (dig "topology" "mode" "GaleraCluster" .spec) "MariaDBReplication") }}true{{ else }}false{{ end -}}'
     title: KubeDB / MariaDB / Galera-Cluster
     vars:
     - name: namespace

--- a/hub/resourcedashboards/kubedb.com/v1alpha2/memcacheds.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1alpha2/memcacheds.yaml
@@ -16,17 +16,7 @@ spec:
     - name: app
       value: '{{ .metadata.name }}'
   - title: KubeDB / Memcached / Database
-    vars:
-    - name: namespace
-      value: '{{ .metadata.namespace }}'
-    - name: app
-      value: '{{ .metadata.name }}'
   - title: KubeDB / Memcached / Pod
-    vars:
-    - name: namespace
-      value: '{{ .metadata.namespace }}'
-    - name: app
-      value: '{{ .metadata.name }}'
   provider: Grafana
   resource:
     group: kubedb.com

--- a/hub/resourcedashboards/kubedb.com/v1alpha2/memcacheds.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1alpha2/memcacheds.yaml
@@ -8,7 +8,25 @@ metadata:
     k8s.io/version: v1alpha2
   name: kubedb.com-v1alpha2-memcacheds
 spec:
-  dashboards: null
+  dashboards:
+  - title: KubeDB / Memcached / Summary
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
+  - title: KubeDB / Memcached / Database
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
+  - title: KubeDB / Memcached / Pod
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
   provider: Grafana
   resource:
     group: kubedb.com

--- a/hub/resourcedashboards/kubedb.com/v1alpha2/milvuses.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1alpha2/milvuses.yaml
@@ -21,12 +21,6 @@ spec:
       value: '{{ .metadata.namespace }}'
     - name: app
       value: '{{ .metadata.name }}'
-  - title: KubeDB / Milvus / Pod
-    vars:
-    - name: namespace
-      value: '{{ .metadata.namespace }}'
-    - name: app
-      value: '{{ .metadata.name }}'
   provider: Grafana
   resource:
     group: kubedb.com

--- a/hub/resourcedashboards/kubedb.com/v1alpha2/milvuses.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1alpha2/milvuses.yaml
@@ -19,8 +19,6 @@ spec:
     vars:
     - name: namespace
       value: '{{ .metadata.namespace }}'
-    - name: app
-      value: '{{ .metadata.name }}'
   provider: Grafana
   resource:
     group: kubedb.com

--- a/hub/resourcedashboards/kubedb.com/v1alpha2/perconaxtradbs.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1alpha2/perconaxtradbs.yaml
@@ -8,7 +8,33 @@ metadata:
     k8s.io/version: v1alpha2
   name: kubedb.com-v1alpha2-perconaxtradbs
 spec:
-  dashboards: null
+  dashboards:
+  - title: KubeDB / PerconaXtraDB / Summary
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
+  - if:
+      condition: '{{- if eq .spec.replicas 1 }}false{{ else }}true{{ end -}}'
+    title: KubeDB / PerconaXtraDB / Galera-Cluster
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
+  - title: KubeDB / PerconaXtraDB / Database
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
+  - title: KubeDB / PerconaXtraDB / Pod
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
   provider: Grafana
   resource:
     group: kubedb.com

--- a/hub/resourcedashboards/kubedb.com/v1alpha2/pgbouncers.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1alpha2/pgbouncers.yaml
@@ -8,7 +8,25 @@ metadata:
     k8s.io/version: v1alpha2
   name: kubedb.com-v1alpha2-pgbouncers
 spec:
-  dashboards: null
+  dashboards:
+  - title: KubeDB / PgBouncer / Summary
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
+  - title: KubeDB / PgBouncer / Database
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
+  - title: KubeDB / PgBouncer / Pod
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
   provider: Grafana
   resource:
     group: kubedb.com

--- a/hub/resourcedashboards/kubedb.com/v1alpha2/pod/cassandras.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1alpha2/pod/cassandras.yaml
@@ -1,0 +1,18 @@
+apiVersion: ui.k8s.appscode.com/v1alpha1
+kind: ResourceDashboard
+metadata:
+  name: kubedb.com-v1alpha2-cassandras-pod
+spec:
+  dashboards:
+  - title: KubeDB / Cassandra / Pod
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
+    - name: pod
+      type: Target
+      value: '{{ .metadata.name }}'
+  provider: Grafana
+  resource:
+    group: ""

--- a/hub/resourcedashboards/kubedb.com/v1alpha2/pod/cassandras.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1alpha2/pod/cassandras.yaml
@@ -6,10 +6,6 @@ spec:
   dashboards:
   - title: KubeDB / Cassandra / Pod
     vars:
-    - name: namespace
-      value: '{{ .metadata.namespace }}'
-    - name: app
-      value: '{{ .metadata.name }}'
     - name: pod
       type: Target
       value: '{{ .metadata.name }}'

--- a/hub/resourcedashboards/kubedb.com/v1alpha2/pod/clickhouses.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1alpha2/pod/clickhouses.yaml
@@ -1,0 +1,18 @@
+apiVersion: ui.k8s.appscode.com/v1alpha1
+kind: ResourceDashboard
+metadata:
+  name: kubedb.com-v1alpha2-clickhouses-pod
+spec:
+  dashboards:
+  - title: KubeDB / ClickHouse / Pod
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
+    - name: pod
+      type: Target
+      value: '{{ .metadata.name }}'
+  provider: Grafana
+  resource:
+    group: ""

--- a/hub/resourcedashboards/kubedb.com/v1alpha2/pod/druids.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1alpha2/pod/druids.yaml
@@ -1,0 +1,18 @@
+apiVersion: ui.k8s.appscode.com/v1alpha1
+kind: ResourceDashboard
+metadata:
+  name: kubedb.com-v1alpha2-druids-pod
+spec:
+  dashboards:
+  - title: KubeDB / Druid / Pod
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
+    - name: pod
+      type: Target
+      value: '{{ .metadata.name }}'
+  provider: Grafana
+  resource:
+    group: ""

--- a/hub/resourcedashboards/kubedb.com/v1alpha2/pod/hazelcasts.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1alpha2/pod/hazelcasts.yaml
@@ -1,0 +1,18 @@
+apiVersion: ui.k8s.appscode.com/v1alpha1
+kind: ResourceDashboard
+metadata:
+  name: kubedb.com-v1alpha2-hazelcasts-pod
+spec:
+  dashboards:
+  - title: KubeDB / Hazelcast / Pod
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
+    - name: pod
+      type: Target
+      value: '{{ .metadata.name }}'
+  provider: Grafana
+  resource:
+    group: ""

--- a/hub/resourcedashboards/kubedb.com/v1alpha2/pod/ignites.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1alpha2/pod/ignites.yaml
@@ -1,0 +1,18 @@
+apiVersion: ui.k8s.appscode.com/v1alpha1
+kind: ResourceDashboard
+metadata:
+  name: kubedb.com-v1alpha2-ignites-pod
+spec:
+  dashboards:
+  - title: KubeDB / Ignite / Pod
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
+    - name: pod
+      type: Target
+      value: '{{ .metadata.name }}'
+  provider: Grafana
+  resource:
+    group: ""

--- a/hub/resourcedashboards/kubedb.com/v1alpha2/pod/ignites.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1alpha2/pod/ignites.yaml
@@ -5,14 +5,6 @@ metadata:
 spec:
   dashboards:
   - title: KubeDB / Ignite / Pod
-    vars:
-    - name: namespace
-      value: '{{ .metadata.namespace }}'
-    - name: app
-      value: '{{ .metadata.name }}'
-    - name: pod
-      type: Target
-      value: '{{ .metadata.name }}'
   provider: Grafana
   resource:
     group: ""

--- a/hub/resourcedashboards/kubedb.com/v1alpha2/pod/mssqlservers.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1alpha2/pod/mssqlservers.yaml
@@ -1,0 +1,18 @@
+apiVersion: ui.k8s.appscode.com/v1alpha1
+kind: ResourceDashboard
+metadata:
+  name: kubedb.com-v1alpha2-mssqlservers-pod
+spec:
+  dashboards:
+  - title: KubeDB / MSSQLServer / Pod
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
+    - name: pod
+      type: Target
+      value: '{{ .metadata.name }}'
+  provider: Grafana
+  resource:
+    group: ""

--- a/hub/resourcedashboards/kubedb.com/v1alpha2/pod/neo4js.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1alpha2/pod/neo4js.yaml
@@ -1,0 +1,18 @@
+apiVersion: ui.k8s.appscode.com/v1alpha1
+kind: ResourceDashboard
+metadata:
+  name: kubedb.com-v1alpha2-neo4js-pod
+spec:
+  dashboards:
+  - title: KubeDB / Neo4j / Pod
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
+    - name: pod
+      type: Target
+      value: '{{ .metadata.name }}'
+  provider: Grafana
+  resource:
+    group: ""

--- a/hub/resourcedashboards/kubedb.com/v1alpha2/pod/oracles.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1alpha2/pod/oracles.yaml
@@ -1,0 +1,18 @@
+apiVersion: ui.k8s.appscode.com/v1alpha1
+kind: ResourceDashboard
+metadata:
+  name: kubedb.com-v1alpha2-oracles-pod
+spec:
+  dashboards:
+  - title: KubeDB / Oracle / Pod
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
+    - name: pod
+      type: Target
+      value: '{{ .metadata.name }}'
+  provider: Grafana
+  resource:
+    group: ""

--- a/hub/resourcedashboards/kubedb.com/v1alpha2/pod/perconaxtradbs.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1alpha2/pod/perconaxtradbs.yaml
@@ -1,0 +1,18 @@
+apiVersion: ui.k8s.appscode.com/v1alpha1
+kind: ResourceDashboard
+metadata:
+  name: kubedb.com-v1alpha2-perconaxtradbs-pod
+spec:
+  dashboards:
+  - title: KubeDB / PerconaXtraDB / Pod
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
+    - name: pod
+      type: Target
+      value: '{{ .metadata.name }}'
+  provider: Grafana
+  resource:
+    group: ""

--- a/hub/resourcedashboards/kubedb.com/v1alpha2/pod/pgbouncers.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1alpha2/pod/pgbouncers.yaml
@@ -1,0 +1,18 @@
+apiVersion: ui.k8s.appscode.com/v1alpha1
+kind: ResourceDashboard
+metadata:
+  name: kubedb.com-v1alpha2-pgbouncers-pod
+spec:
+  dashboards:
+  - title: KubeDB / PgBouncer / Pod
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
+    - name: pod
+      type: Target
+      value: '{{ .metadata.name }}'
+  provider: Grafana
+  resource:
+    group: ""

--- a/hub/resourcedashboards/kubedb.com/v1alpha2/pod/pgpools.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1alpha2/pod/pgpools.yaml
@@ -1,0 +1,18 @@
+apiVersion: ui.k8s.appscode.com/v1alpha1
+kind: ResourceDashboard
+metadata:
+  name: kubedb.com-v1alpha2-pgpools-pod
+spec:
+  dashboards:
+  - title: KubeDB / Pgpool / Pod
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
+    - name: pod
+      type: Target
+      value: '{{ .metadata.name }}'
+  provider: Grafana
+  resource:
+    group: ""

--- a/hub/resourcedashboards/kubedb.com/v1alpha2/pod/qdrants.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1alpha2/pod/qdrants.yaml
@@ -1,0 +1,18 @@
+apiVersion: ui.k8s.appscode.com/v1alpha1
+kind: ResourceDashboard
+metadata:
+  name: kubedb.com-v1alpha2-qdrants-pod
+spec:
+  dashboards:
+  - title: KubeDB / Qdrant / Pod
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
+    - name: pod
+      type: Target
+      value: '{{ .metadata.name }}'
+  provider: Grafana
+  resource:
+    group: ""

--- a/hub/resourcedashboards/kubedb.com/v1alpha2/pod/rabbitmqs.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1alpha2/pod/rabbitmqs.yaml
@@ -1,0 +1,18 @@
+apiVersion: ui.k8s.appscode.com/v1alpha1
+kind: ResourceDashboard
+metadata:
+  name: kubedb.com-v1alpha2-rabbitmqs-pod
+spec:
+  dashboards:
+  - title: KubeDB / RabbitMQ / Pod
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
+    - name: pod
+      type: Target
+      value: '{{ .metadata.name }}'
+  provider: Grafana
+  resource:
+    group: ""

--- a/hub/resourcedashboards/kubedb.com/v1alpha2/pod/singlestores.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1alpha2/pod/singlestores.yaml
@@ -1,0 +1,18 @@
+apiVersion: ui.k8s.appscode.com/v1alpha1
+kind: ResourceDashboard
+metadata:
+  name: kubedb.com-v1alpha2-singlestores-pod
+spec:
+  dashboards:
+  - title: KubeDB / Singlestore / Pod
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
+    - name: pod
+      type: Target
+      value: '{{ .metadata.name }}'
+  provider: Grafana
+  resource:
+    group: ""

--- a/hub/resourcedashboards/kubedb.com/v1alpha2/pod/solrs.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1alpha2/pod/solrs.yaml
@@ -1,0 +1,18 @@
+apiVersion: ui.k8s.appscode.com/v1alpha1
+kind: ResourceDashboard
+metadata:
+  name: kubedb.com-v1alpha2-solrs-pod
+spec:
+  dashboards:
+  - title: KubeDB / Solr / Pod
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
+    - name: pod
+      type: Target
+      value: '{{ .metadata.name }}'
+  provider: Grafana
+  resource:
+    group: ""

--- a/hub/resourcedashboards/kubedb.com/v1alpha2/pod/weaviates.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1alpha2/pod/weaviates.yaml
@@ -1,0 +1,18 @@
+apiVersion: ui.k8s.appscode.com/v1alpha1
+kind: ResourceDashboard
+metadata:
+  name: kubedb.com-v1alpha2-weaviates-pod
+spec:
+  dashboards:
+  - title: KubeDB / Weaviate / Pod
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
+    - name: pod
+      type: Target
+      value: '{{ .metadata.name }}'
+  provider: Grafana
+  resource:
+    group: ""

--- a/hub/resourcedashboards/kubedb.com/v1alpha2/pod/zookeepers.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1alpha2/pod/zookeepers.yaml
@@ -1,0 +1,18 @@
+apiVersion: ui.k8s.appscode.com/v1alpha1
+kind: ResourceDashboard
+metadata:
+  name: kubedb.com-v1alpha2-zookeepers-pod
+spec:
+  dashboards:
+  - title: KubeDB / ZooKeeper / Pod
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
+    - name: pod
+      type: Target
+      value: '{{ .metadata.name }}'
+  provider: Grafana
+  resource:
+    group: ""

--- a/hub/resourcedashboards/kubedb.com/v1alpha2/postgreses.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1alpha2/postgreses.yaml
@@ -15,6 +15,14 @@ spec:
       value: '{{ .metadata.namespace }}'
     - name: app
       value: '{{ .metadata.name }}'
+  - if:
+      condition: '{{- if hasKey .spec "remoteReplica" }}true{{ else }}false{{ end -}}'
+    title: KubeDB / Postgres / Remote Replica
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
   - title: KubeDB / Postgres / Database
     vars:
     - name: namespace

--- a/hub/resourcedashboards/kubedb.com/v1alpha2/redissentinels.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1alpha2/redissentinels.yaml
@@ -8,7 +8,19 @@ metadata:
     k8s.io/version: v1alpha2
   name: kubedb.com-v1alpha2-redissentinels
 spec:
-  dashboards: null
+  dashboards:
+  - title: KubeDB / RedisSentinel / Summary
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
+  - title: KubeDB / RedisSentinel / Pod
+    vars:
+    - name: namespace
+      value: '{{ .metadata.namespace }}'
+    - name: app
+      value: '{{ .metadata.name }}'
   provider: Grafana
   resource:
     group: kubedb.com

--- a/hub/resourcedashboards/kubedb.com/v1alpha2/zookeeper.yaml
+++ b/hub/resourcedashboards/kubedb.com/v1alpha2/zookeeper.yaml
@@ -15,7 +15,7 @@ spec:
       value: '{{ .metadata.namespace }}'
     - name: app
       value: '{{ .metadata.name }}'
-  - title: KubeDB / ZooKeeper / Database
+  - title: KubeDB / ZooKeeper / Ensemble
     vars:
     - name: namespace
       value: '{{ .metadata.namespace }}'

--- a/hub/resourcetabledefinitions/core.k8s.appscode.com/v1alpha1/kubedb/podviews-db2s.yaml
+++ b/hub/resourcetabledefinitions/core.k8s.appscode.com/v1alpha1/kubedb/podviews-db2s.yaml
@@ -68,12 +68,6 @@ spec:
       template: '{{ .metadata.creationTimestamp | toDate "2006-01-02T15:04:05Z07:00" | unixEpoch }}'
       type: integer
     type: date
-  - dashboard:
-      name: kubedb.com-v1alpha2-db2s-pod
-    name: Dashboard
-    priority: 4
-    textAlign: center
-    type: string
   - exec: {}
     name: Connect
     pathTemplate: '{{ .metadata.name }}'

--- a/hub/resourcetabledefinitions/core.k8s.appscode.com/v1alpha1/kubedb/podviews-documentdbs.yaml
+++ b/hub/resourcetabledefinitions/core.k8s.appscode.com/v1alpha1/kubedb/podviews-documentdbs.yaml
@@ -68,12 +68,6 @@ spec:
       template: '{{ .metadata.creationTimestamp | toDate "2006-01-02T15:04:05Z07:00" | unixEpoch }}'
       type: integer
     type: date
-  - dashboard:
-      name: kubedb.com-v1alpha2-documentdbs-pod
-    name: Dashboard
-    priority: 4
-    textAlign: center
-    type: string
   - exec: {}
     name: Connect
     pathTemplate: '{{ .metadata.name }}'

--- a/hub/resourcetabledefinitions/core.k8s.appscode.com/v1alpha1/kubedb/podviews-hanadbs.yaml
+++ b/hub/resourcetabledefinitions/core.k8s.appscode.com/v1alpha1/kubedb/podviews-hanadbs.yaml
@@ -68,12 +68,6 @@ spec:
       template: '{{ .metadata.creationTimestamp | toDate "2006-01-02T15:04:05Z07:00" | unixEpoch }}'
       type: integer
     type: date
-  - dashboard:
-      name: kubedb.com-v1alpha2-hanadbs-pod
-    name: Dashboard
-    priority: 4
-    textAlign: center
-    type: string
   - exec: {}
     name: Connect
     pathTemplate: '{{ .metadata.name }}'

--- a/hub/resourcetabledefinitions/core.k8s.appscode.com/v1alpha1/kubedb/podviews-milvuses.yaml
+++ b/hub/resourcetabledefinitions/core.k8s.appscode.com/v1alpha1/kubedb/podviews-milvuses.yaml
@@ -68,12 +68,6 @@ spec:
       template: '{{ .metadata.creationTimestamp | toDate "2006-01-02T15:04:05Z07:00" | unixEpoch }}'
       type: integer
     type: date
-  - dashboard:
-      name: kubedb.com-v1alpha2-milvuses-pod
-    name: Dashboard
-    priority: 4
-    textAlign: center
-    type: string
   - exec: {}
     name: Connect
     pathTemplate: '{{ .metadata.name }}'


### PR DESCRIPTION
`RenderDashboard` returned `dashboards: []` for a number of KubeDB kinds because the
`ResourceDashboard` in the hub had `spec.dashboards: null`. PgBouncer was the reported
case; the same gap existed for Memcached, PerconaXtraDB, RedisSentinel and Weaviate,
and several other kinds were missing individual dashboards the charts ship.

Source of truth for every title and variable in this PR is
`kubedb.dev/installer/charts/kubedb-grafana-dashboards`, helm-rendered and read from
`.spec.model.title` / `.spec.model.templating.list` (92 dashboards).

`charts/kubedb-perses-dashboards` was checked too: its 89 display names are a strict
subset of the Grafana titles (only Weaviate x3 differ), so it contributes no new names.
See "Perses" below.

## Commits

**Populate missing KubeDB ResourceDashboards from the dashboard charts**
Filled in where `dashboards` was `null` — Memcached, PerconaXtraDB, PgBouncer,
RedisSentinel (v1 and v1alpha2) and Weaviate (v1alpha2). Completed Kafka (gains Summary
and Pod), MariaDB (Standard Replication) and Postgres (Remote Replica). Added
`kafka.kubedb.com/v1alpha1/connectclusters.yaml` for the three Kafka / ConnectCluster
dashboards.

New conditions read the real API fields: `spec.topology.mode` for MariaDB (enum is
`MariaDBReplication|GaleraCluster`) and `spec.remoteReplica` for Postgres.

**Add the missing pod ResourceDashboards for KubeDB kinds**
`hub/resourcetabledefinitions/core.k8s.appscode.com/v1alpha1/kubedb/podviews-*.yaml`
references 28 `<resource>-pod` ResourceDashboards; only 7 existed, so the Dashboard
column in 21 pod views could not resolve. Adds the 17 v1alpha2 dashboards the charts
ship a Pod dashboard for, plus v1 copies for `perconaxtradbs` and `pgbouncers`.

Dangling references: 21 -> 4.

**Drop ResourceDashboard titles that no dashboard chart ships**
Neither chart ships `KubeDB / HanaDB / Pod` or `KubeDB / Milvus / Pod`, so those two
entries never resolved. ZooKeeper ships `Ensemble`, not `Database`.

**Only pass dashboard vars the dashboard actually declares**
Every entry passed `namespace` and `app` regardless of the dashboard's own templating
list, so those values were inert wherever a dashboard declares something else —
Cassandra Database/Pod use `cluster`+`datacenter`, HanaDB Database uses
`node_name`/`node_ip`/`sid`/`instance_number`/`database_name`, Memcached Database uses
`job`, Ignite Database has `app` but no `namespace`, Milvus Database has `namespace` but
no `app`.

**Do not show the MariaDB Galera-Cluster dashboard for standard replication**
The condition was `replicas != 1`, which is also true for `spec.topology.mode:
MariaDBReplication`, so both Galera-Cluster and Standard Replication rendered for a
standard-replication cluster. `spec.topology` is optional and a MariaDB with
`replicas > 1` and no topology is Galera, hence `GaleraCluster` as the missing-key
default.

## Verification

- `go build ./...` clean
- `make fmt` (including `cmd/resource-fmt`) idempotent, tree clean afterwards
- every `title:` under `hub/resourcedashboards/` now resolves to a dashboard the chart
  ships — 0 orphans, was 3
- both MariaDB conditions and the Postgres one were rendered through
  `kubeops.dev/ui-server/pkg/shared.RenderTemplate` against unstructured input for
  `replicas=1`, `replicas=3` with no topology, `replicas=3` GaleraCluster and
  `replicas=3` MariaDBReplication before being committed

`go run ./cmd/check-schema/main.go` panics with
`trigger: error unmarshaling JSON: cannot unmarshal string into map[string]interface {}`.
It panics identically on a clean `master`, so it is pre-existing and unrelated to this
PR, but it means `check-schema` did not run as a gate here.

## Known gaps, not addressed here

- `db2s`, `documentdbs`, `hanadbs` and `milvuses` still have unresolvable `-pod`
  references, because no chart ships a Pod dashboard for them. `podviews-hanadbs.yaml`
  and `podviews-milvuses.yaml` should probably drop their `dashboard:` column — that is
  a `resourcetabledefinitions` change.
- `KubeDB / Ignite / Pod` declares `job`, `cacheName` and `node` but no `pod`, so
  `kubedb.com-v1alpha2-ignites-pod` resolves but cannot scope to a pod. The dashboard
  needs a `pod` variable in the chart before that entry does anything useful.
- `db2s` and `documentdb` keep `dashboards: null`; neither chart ships anything for them.

## Perses

Not touched, and deliberately so. `DashboardProvider` is
`+kubebuilder:validation:Enum=Grafana` (`apis/ui/v1alpha1/resourcedashboard_types.go:50`),
so adding a `Perses` constant would make the CRD start accepting `provider: Perses`.
`kubeops.dev/ui-server` then rejects it at render time
(`pkg/graph/dashboard.go:81`), turning an up-front validation error into a runtime one.

The blocker is upstream: `go.openviz.dev/apimachinery` v0.0.10 is the newest published
version and ships no Perses types, so there is no `ui.openviz.dev` group/render
resource for `RenderDashboard` to POST to the way it POSTs `DashboardGroup` today.
`openviz.dev/v1alpha1 PersesDashboard` (in the perses chart's `crds/`) is the storage
CRD, not a render API. Worth revisiting once openviz grows the UI side.
