### PR TITLE
Skip non-YAML files in check-schema

### DIFF
--- a/cmd/check-schema/main.go
+++ b/cmd/check-schema/main.go
@@ -17,6 +17,10 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
+	"io/fs"
+	"path/filepath"
+
 	"kmodules.xyz/resource-metadata/apis/meta/v1alpha1"
 	uiapi "kmodules.xyz/resource-metadata/apis/ui/v1alpha1"
 	blockdefs "kmodules.xyz/resource-metadata/hub/resourceblockdefinitions"
@@ -28,19 +32,37 @@ import (
 )
 
 func main() {
-	if err := sc.CheckFS(blockdefs.EmbeddedFS(), &v1alpha1.ResourceBlockDefinition{}); err != nil {
+	if err := checkYAMLs(blockdefs.EmbeddedFS(), &v1alpha1.ResourceBlockDefinition{}); err != nil {
 		panic(err)
 	}
-	if err := sc.CheckFS(resourcedescriptors.EmbeddedFS(), &v1alpha1.ResourceDescriptor{}); err != nil {
+	if err := checkYAMLs(resourcedescriptors.EmbeddedFS(), &v1alpha1.ResourceDescriptor{}); err != nil {
 		panic(err)
 	}
-	if err := sc.CheckFS(resourceoutlines.EmbeddedFS(), &v1alpha1.ResourceOutline{}); err != nil {
+	if err := checkYAMLs(resourceoutlines.EmbeddedFS(), &v1alpha1.ResourceOutline{}); err != nil {
 		panic(err)
 	}
-	if err := sc.CheckFS(tabledefs.EmbeddedFS(), &v1alpha1.ResourceTableDefinition{}); err != nil {
+	if err := checkYAMLs(tabledefs.EmbeddedFS(), &v1alpha1.ResourceTableDefinition{}); err != nil {
 		panic(err)
 	}
-	if err := sc.CheckFS(dashboards.EmbeddedFS(), &uiapi.ResourceDashboard{}); err != nil {
+	if err := checkYAMLs(dashboards.EmbeddedFS(), &uiapi.ResourceDashboard{}); err != nil {
 		panic(err)
 	}
+}
+
+// hub packages embed a non-YAML "trigger" sentinel file for hot reload,
+// which sc.CheckFS would try to parse as an object.
+func checkYAMLs(fsys fs.FS, v interface{}) error {
+	return fs.WalkDir(fsys, ".", func(path string, e fs.DirEntry, err error) error {
+		if err != nil || e.IsDir() || filepath.Ext(path) != ".yaml" {
+			return err
+		}
+		d, err := sc.New(fsys).CheckObject(v, path)
+		if err != nil {
+			return err
+		}
+		if d != "" {
+			return fmt.Errorf("%s: object does not match schema, diff: %s", path, d)
+		}
+		return nil
+	})
 }


### PR DESCRIPTION
`go run ./cmd/check-schema/main.go` panics on a clean master:

```
panic: trigger: trigger: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type map[string]interface {}
```

Every hub package embeds a sentinel file named `trigger` whose content is the literal string `load` — the hot-reload trigger documented in `hub/README.md`, added in 56330dbf4. `sc.CheckFS` walks *every* file in the embedded FS with no extension filter (`vendor/kmodules.xyz/schema-checker/lib.go:244`), so it hits `trigger` and fails to unmarshal it as an object. The panic fires on the first package before a single real YAML is checked.

Fixed locally with a `checkYAMLs` helper that filters to `*.yaml` before delegating to `sc.New(fsys).CheckObject`, rather than bumping `kmodules.xyz/schema-checker` for the same filter upstream.

After this, `check-schema` exits 0 — the `trigger` file was the only failure; all hub YAML matches its schema.

Note: the tool isn't wired into `make fmt` or `make ci`, which is why CI never caught this.