### PR TITLE
Add backup & restore actions for Milvus

### DIFF
--- a/hub/resourceeditors/kubedb.com/v1alpha2/milvuses.yaml
+++ b/hub/resourceeditors/kubedb.com/v1alpha2/milvuses.yaml
@@ -23,6 +23,53 @@ spec:
     actions:
     - items:
       - editor:
+          name: kubedbcom-milvus-editor
+          sourceRef:
+            apiGroup: source.toolkit.fluxcd.io
+            kind: HelmRepository
+            name: appscode-wizards-oci
+          version: v0.36.0
+        enforceQuota: false
+        flow: standalone-edit
+        icon: material-symbols-light:backup-outline
+        icons:
+        - src: https://cdn.appscode.com/k8s/icons/action-icons/configure-backup.svg
+          type: image/svg+xml
+        name: Configure Backup
+        operationId: edit-self-backupconfiguration
+      - editor:
+          name: corekubestashcom-backupsession-editor
+          sourceRef:
+            apiGroup: source.toolkit.fluxcd.io
+            kind: HelmRepository
+            name: appscode-wizards-oci
+          version: v0.36.0
+        enforceQuota: false
+        flow: standalone-create
+        icon: carbon:ibm-cloud-backup-and-recovery
+        icons:
+        - src: https://cdn.appscode.com/k8s/icons/action-icons/instant-backup.svg
+          type: image/svg+xml
+        name: Instant Backup
+        operationId: create-instant-backup
+      - editor:
+          name: corekubestashcom-restoresession-editor-options
+          sourceRef:
+            apiGroup: source.toolkit.fluxcd.io
+            kind: HelmRepository
+            name: appscode-wizards-oci
+          version: v0.36.0
+        enforceQuota: false
+        flow: standalone-create
+        icon: mdi:backup-restore
+        icons:
+        - src: https://cdn.appscode.com/k8s/icons/action-icons/restore.svg
+          type: image/svg+xml
+        name: Restore
+        operationId: create-restoresession
+      name: Backups
+    - items:
+      - editor:
           name: opskubedbcom-milvusopsrequest-editor
           sourceRef:
             apiGroup: source.toolkit.fluxcd.io

--- a/hub/resourceoutlines/kubedb.com/v1alpha2/kubedb/milvuses.yaml
+++ b/hub/resourceoutlines/kubedb.com/v1alpha2/kubedb/milvuses.yaml
@@ -166,6 +166,15 @@ spec:
           sort:
             fieldName: Age
             order: Ascending
+  - icon: carbon:data-backup
+    name: Backup
+    requiredFeatureSets:
+      opscenter-backup:
+      - kubestash
+    sections:
+    - blocks:
+      - kind: Block
+        name: core.kubestash.com-v1alpha1-kubedb-backup
   - icon: hugeicons:database-locked
     name: Security
     sections:


### PR DESCRIPTION
Milvus was missing the backup/restore UI wiring that other backup-capable databases already have.

- `hub/resourceeditors/kubedb.com/v1alpha2/milvuses.yaml` — add the `Backups` action group: Configure Backup (`edit-self-backupconfiguration`), Instant Backup (`create-instant-backup`), Restore (`create-restoresession`).
- `hub/resourceoutlines/kubedb.com/v1alpha2/kubedb/milvuses.yaml` — add the `Backup` page rendering `core.kubestash.com-v1alpha1-kubedb-backup`, gated on `opscenter-backup: kubestash`.

Autoscaling needed no change: the `Autoscaling` action group (Compute + Storage) and the `milvusautoscalers` editor/table definition were already present and match the other databases.

Milvus is already listed in the KubeStash `backupconfigurations` / `restoresessions` resource descriptors, so no descriptor change was needed.

Verified with `check-edge-label`, `resource-fmt` (both clean, no further diff) and `go build ./...`.